### PR TITLE
VZ-9441.  Implement a lifeycycle class for POC helm controller

### DIFF
--- a/module-operator/apis/platform/v1alpha1/modulelifecycle_types.go
+++ b/module-operator/apis/platform/v1alpha1/modulelifecycle_types.go
@@ -87,6 +87,10 @@ type ModuleLifecycleCondition struct {
 // LifecycleClassType Identifies the lifecycle class used to manage a subset of Module types
 type LifecycleClassType string
 
+const (
+	HelmLifecycleClass = "helm"
+)
+
 // ActionType defines the type of action to be performed in a ModuleLifecycle instance
 type ActionType string
 

--- a/module-operator/controllers/modlifecycle/module_lifecycle_controller.go
+++ b/module-operator/controllers/modlifecycle/module_lifecycle_controller.go
@@ -6,6 +6,8 @@ package modlifecycle
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"time"
 
 	modulesv1alpha1 "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
@@ -29,9 +31,12 @@ type Reconciler struct {
 	Controller controller.Controller
 }
 
+const POCLifecycleClass = "helmpoc"
+
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&modulesv1alpha1.ModuleLifecycle{}).
+		WithEventFilter(r.createPredicateFilter()).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 10,
 		}).
@@ -88,6 +93,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return handleError(log, mlc, err)
 	}
 	return result, nil
+}
+
+func (r *Reconciler) createPredicateFilter() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return r.handlesEvent(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return r.handlesEvent(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return r.handlesEvent(e.ObjectOld)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return r.handlesEvent(e.Object)
+		},
+	}
+}
+
+func (r *Reconciler) handlesEvent(object client.Object) bool {
+	mlc := modulesv1alpha1.ModuleLifecycle{}
+	objectkey := client.ObjectKeyFromObject(object)
+	if err := r.Get(context.TODO(), objectkey, &mlc); err != nil {
+		zap.S().Errorf("Failed to get ModuleLifecycle %s", objectkey)
+		return false
+	}
+	handlesEvent := mlc.Spec.LifecycleClass == POCLifecycleClass
+	zap.S().Debugf("POC Helm controller event filter result for %s: %v", objectkey, handlesEvent)
+	return handlesEvent
 }
 
 func handleError(log vzlog.VerrazzanoLogger, mlc *modulesv1alpha1.ModuleLifecycle, err error) (ctrl.Result, error) {

--- a/module-operator/controllers/module/module_controller.go
+++ b/module-operator/controllers/module/module_controller.go
@@ -4,6 +4,7 @@ package module
 
 import (
 	"context"
+	"github.com/verrazzano/verrazzano-modules/module-operator/controllers/modlifecycle"
 	"time"
 
 	modulesv1alpha1 "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
@@ -159,6 +160,8 @@ func (r *Reconciler) createLifecycleResource(sourceName string, sourceURI string
 			moduleInstaller.ObjectMeta.Labels = make(map[string]string)
 		}
 		moduleInstaller.Spec = modulesv1alpha1.ModuleLifecycleSpec{
+			// For now
+			LifecycleClass: modlifecycle.POCLifecycleClass,
 			Installer: modulesv1alpha1.ModuleInstaller{
 				HelmRelease: &modulesv1alpha1.HelmRelease{
 					Name:      chartName, // REVIEW: should this be associated with the Module name?

--- a/module-operator/controllers/module/module_controller.go
+++ b/module-operator/controllers/module/module_controller.go
@@ -160,7 +160,6 @@ func (r *Reconciler) createLifecycleResource(sourceName string, sourceURI string
 			moduleInstaller.ObjectMeta.Labels = make(map[string]string)
 		}
 		moduleInstaller.Spec = modulesv1alpha1.ModuleLifecycleSpec{
-			// For now
 			LifecycleClass: modlifecycle.POCLifecycleClass,
 			Installer: modulesv1alpha1.ModuleInstaller{
 				HelmRelease: &modulesv1alpha1.HelmRelease{


### PR DESCRIPTION
Use a fake lifecycle class used by the in-operator POC Helm controller; this will help prove out the integration and allow development to continue in parallel.