### PR TITLE
Use Verrazzano base image for operator containers

### DIFF
--- a/calico-operator/Dockerfile
+++ b/calico-operator/Dockerfile
@@ -1,16 +1,16 @@
 # Build the manager binary
-FROM ghcr.io/oracle/oraclelinux:8-slim AS build_base
+FROM ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230327155846-4653b27 AS build_base
 
-# Need to use specific WORKDIR to match source packages
 WORKDIR /root/go/src/github.com/verrazzano/verrazzano-modules/calico-operator
 COPY . .
 
 COPY bin/linux_amd64/verrazzano-calico-operator /usr/local/bin/verrazzano-calico-operator
 
+# Copy the operator binary
 RUN chmod 500 /usr/local/bin/verrazzano-calico-operator
 
 # Create the verrazzano-calico-operator image
-FROM ghcr.io/oracle/oraclelinux:8-slim AS final
+FROM ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230327155846-4653b27 AS final
 
 RUN groupadd -r verrazzano \
     && useradd --no-log-init -r -m -d /verrazzano -g verrazzano -u 1000 verrazzano \

--- a/helm-operator/Dockerfile
+++ b/helm-operator/Dockerfile
@@ -1,19 +1,19 @@
 # Copyright (C) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-# Build the manager binary
-FROM ghcr.io/oracle/oraclelinux:8-slim AS build_base
+FROM ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230327155846-4653b27 AS build_base
 
 # Need to use specific WORKDIR to match source packages
 WORKDIR /root/go/src/github.com/verrazzano/verrazzano-modules/helm-operator
 COPY . .
 
+# Copy the operator binary
 COPY bin/linux_amd64/verrazzano-helm-operator /usr/local/bin/verrazzano-helm-operator
 
 RUN chmod 500 /usr/local/bin/verrazzano-helm-operator
 
 # Create the verrazzano-helm-operator image
-FROM ghcr.io/oracle/oraclelinux:8-slim AS final
+FROM ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230327155846-4653b27 AS final
 
 RUN groupadd -r verrazzano \
     && useradd --no-log-init -r -m -d /verrazzano -g verrazzano -u 1000 verrazzano \

--- a/module-operator/Dockerfile
+++ b/module-operator/Dockerfile
@@ -1,19 +1,19 @@
 # Copyright (C) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-# Build the manager binary
-FROM ghcr.io/oracle/oraclelinux:8-slim AS build_base
+FROM ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230327155846-4653b27 AS build_base
 
 # Need to use specific WORKDIR to match source packages
 WORKDIR /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator
 COPY . .
 
+# Copy the operator binary
 COPY bin/linux_amd64/verrazzano-module-operator /usr/local/bin/verrazzano-module-operator
 
 RUN chmod 500 /usr/local/bin/verrazzano-module-operator
 
 # Create the verrazzano-module-operator image
-FROM ghcr.io/oracle/oraclelinux:8-slim AS final
+FROM ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230327155846-4653b27 AS final
 
 RUN groupadd -r verrazzano \
     && useradd --no-log-init -r -m -d /verrazzano -g verrazzano -u 1000 verrazzano \


### PR DESCRIPTION
Use the latest verrazzano/verrazzano-base image for the verrazzano-modules operator images.