### PR TITLE
VZ-9379 add operator to CR binding using class

### DIFF
--- a/calico-operator/main.go
+++ b/calico-operator/main.go
@@ -7,7 +7,7 @@ import (
 	"flag"
 	"github.com/verrazzano/verrazzano-modules/calico-operator/lifecycle-actions/handlers/factory"
 	"github.com/verrazzano/verrazzano-modules/common/controllers/lifecycle"
-	platformapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
+	moduleplatform "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	"go.uber.org/zap"
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	// init calico lifecycle controller
-	if err := lifecycle.InitController(mgr, factory.NewLifeCycleComponent()); err != nil {
+	if err := lifecycle.InitController(mgr, factory.NewLifeCycleComponent(), moduleplatform.CalicoLifecycleClass); err != nil {
 		log.Errorf("Failed to start Isio Gateway controller", err)
 		return
 	}
@@ -52,7 +52,7 @@ func initScheme() *runtime.Scheme {
 	// Create a scheme then add each GKV group to the scheme
 	scheme := runtime.NewScheme()
 
-	utilruntime.Must(platformapi.AddToScheme(scheme))
+	utilruntime.Must(moduleplatform.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 

--- a/common/controllers/base/basecontroller/manager.go
+++ b/common/controllers/base/basecontroller/manager.go
@@ -4,12 +4,17 @@
 package basecontroller
 
 import (
+	"context"
 	"github.com/verrazzano/verrazzano-modules/common/controllers/base/spi"
 	"github.com/verrazzano/verrazzano-modules/common/controllers/base/watcher"
+	moduleplatform "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -28,6 +33,7 @@ type Reconciler struct {
 	Scheme     *runtime.Scheme
 	Controller controller.Controller
 	ControllerConfig
+	LifecycleClass moduleplatform.LifecycleClassType
 
 	// watcherMap is needed to keep track of which CRs have been initialized
 	// key is the NSN of the Gateway
@@ -35,20 +41,51 @@ type Reconciler struct {
 }
 
 // InitBaseController inits the base controller
-func InitBaseController(mgr controllerruntime.Manager, controllerConfig ControllerConfig) (*Reconciler, error) {
+func InitBaseController(mgr controllerruntime.Manager, controllerConfig ControllerConfig, class moduleplatform.LifecycleClassType) (*Reconciler, error) {
 	r := Reconciler{
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
 		ControllerConfig: controllerConfig,
 		watcherMap:       make(map[string][]watcher.WatchContext),
+		LifecycleClass:   class,
 	}
 
 	var err error
 	r.Controller, err = ctrl.NewControllerManagedBy(mgr).
-		For(controllerConfig.Reconciler.GetReconcileObject()).Build(&r)
+		For(controllerConfig.Reconciler.GetReconcileObject()).
+		WithEventFilter(r.createPredicateFilter()).
+		Build(&r)
 
 	if err != nil {
 		return nil, vzlog.DefaultLogger().ErrorfNewErr("Failed calling SetupWithManager for Istio Gateway controller: %v", err)
 	}
 	return &r, nil
+}
+
+func (r *Reconciler) createPredicateFilter() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return r.handlesEvent(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return r.handlesEvent(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return r.handlesEvent(e.ObjectOld)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return r.handlesEvent(e.Object)
+		},
+	}
+}
+
+func (r *Reconciler) handlesEvent(object client.Object) bool {
+	mlc := moduleplatform.ModuleLifecycle{}
+	objectkey := client.ObjectKeyFromObject(object)
+	if err := r.Get(context.TODO(), objectkey, &mlc); err != nil {
+		zap.S().Errorf("Failed to get ModuleLifecycle %s", objectkey)
+		return false
+	}
+	handlesEvent := mlc.Spec.LifecycleClass == r.LifecycleClass
+	return handlesEvent
 }

--- a/common/controllers/base/basecontroller/manager.go
+++ b/common/controllers/base/basecontroller/manager.go
@@ -86,6 +86,5 @@ func (r *Reconciler) handlesEvent(object client.Object) bool {
 		zap.S().Errorf("Failed to get ModuleLifecycle %s", objectkey)
 		return false
 	}
-	handlesEvent := mlc.Spec.LifecycleClass == r.LifecycleClass
-	return handlesEvent
+	return mlc.Spec.LifecycleClass == r.LifecycleClass
 }

--- a/common/controllers/lifecycle/manager.go
+++ b/common/controllers/lifecycle/manager.go
@@ -7,7 +7,8 @@ import (
 	"github.com/verrazzano/verrazzano-modules/common/controllers/base/basecontroller"
 	spi "github.com/verrazzano/verrazzano-modules/common/controllers/base/spi"
 	compspi "github.com/verrazzano/verrazzano-modules/common/lifecycle-actions/action_spi"
-	vzplatform "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
+	moduleplatform "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
+
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,12 +26,12 @@ var _ spi.Reconciler = Reconciler{}
 var controller Reconciler
 
 // InitController start the  controller
-func InitController(mgr ctrlruntime.Manager, comp compspi.LifecycleComponent) error {
+func InitController(mgr ctrlruntime.Manager, comp compspi.LifecycleComponent, class moduleplatform.LifecycleClassType) error {
 	// The config MUST contain at least the Reconciler.  Other spi interfaces are optional.
 	config := basecontroller.ControllerConfig{
 		Reconciler: &controller,
 	}
-	br, err := basecontroller.InitBaseController(mgr, config)
+	br, err := basecontroller.InitBaseController(mgr, config, class)
 	if err != nil {
 		return err
 	}
@@ -43,5 +44,5 @@ func InitController(mgr ctrlruntime.Manager, comp compspi.LifecycleComponent) er
 
 // GetReconcileObject returns the kind of object being reconciled
 func (r Reconciler) GetReconcileObject() client.Object {
-	return &vzplatform.ModuleLifecycle{}
+	return &moduleplatform.ModuleLifecycle{}
 }

--- a/helm-operator/main.go
+++ b/helm-operator/main.go
@@ -7,7 +7,7 @@ import (
 	"flag"
 	"github.com/verrazzano/verrazzano-modules/common/controllers/lifecycle"
 	"github.com/verrazzano/verrazzano-modules/common/lifecycle-actions/handlers/factory"
-	platformapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
+	moduleplatform "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	"go.uber.org/zap"
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	// init helm lifecycle controller
-	if err := lifecycle.InitController(mgr, factory.NewLifeCycleComponent()); err != nil {
+	if err := lifecycle.InitController(mgr, factory.NewLifeCycleComponent(), moduleplatform.HelmLifecycleClass); err != nil {
 		log.Errorf("Failed to start Isio Gateway controller", err)
 		return
 	}
@@ -51,7 +51,7 @@ func initScheme() *runtime.Scheme {
 	// Create a scheme then add each GKV group to the scheme
 	scheme := runtime.NewScheme()
 
-	utilruntime.Must(platformapi.AddToScheme(scheme))
+	utilruntime.Must(moduleplatform.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 

--- a/module-operator/apis/platform/v1alpha1/modulelifecycle_types.go
+++ b/module-operator/apis/platform/v1alpha1/modulelifecycle_types.go
@@ -87,6 +87,14 @@ type ModuleLifecycleCondition struct {
 // LifecycleClassType Identifies the lifecycle class used to manage a subset of Module types
 type LifecycleClassType string
 
+const (
+	// HelmLifecycleClass defines the class name used by the Helm operator
+	HelmLifecycleClass LifecycleClassType = "helm"
+
+	// CalicoLifecycleClass defines the class name used by the Calico operator
+	CalicoLifecycleClass LifecycleClassType = "calico"
+)
+
 // ActionType defines the type of action to be performed in a ModuleLifecycle instance
 type ActionType string
 


### PR DESCRIPTION
This is Mike Cico's code that i integrated into common.
I added calico class to API  types for now.
Have the helm-operator and calico-operator only process ModuleLifecycle CRs with matching lifecycleClass field.

For example, to install calico:
```
apiVersion: platform.verrazzano.io/v1alpha1
kind: ModuleLifecycle
metadata:
  name: install
spec:
  action: install
  lifecycleClass: calico
  installer:
    helmRelease:
...
```