### PR TITLE
VZ-9379 add finalizer support to common controller

### DIFF
--- a/common/controllers/base/basecontroller/controller.go
+++ b/common/controllers/base/basecontroller/controller.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano-modules/common/controllers/base/spi"
 	"github.com/verrazzano/verrazzano-modules/common/controllers/base/watcher"
+	"github.com/verrazzano/verrazzano-modules/common/pkg/controller/util"
 	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -57,27 +59,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Handle finalizer
-	if r.Finalizer != nil {
+	if r.Finalizer == nil {
+		if err := r.ensureFinalizer(log, cr); err != nil {
+			return newRequeueWithDelay(), nil
+		}
 		if !cr.GetDeletionTimestamp().IsZero() {
 			// Resource is getting deleted
 			if err := r.deleteWatches(); err != nil {
-				return newRequeueWithDelay(), nil
+				return util.NewRequeueWithShortDelay(), nil
 			}
 
 			res, err := r.Cleanup(rctx, cr)
-			if err != nil {
-				return newRequeueWithDelay(), nil
+			if res2 := util.DeriveResult(res, err); res2.Requeue {
+				return res2, nil
 			}
-			if err != nil {
-				return newRequeueWithDelay(), nil
+
+			if err := r.deleteFinalizer(log, cr); err != nil {
+				return util.NewRequeueWithShortDelay(), nil
 			}
-			if vzctrl.ShouldRequeue(res) {
-				return res, nil
-			}
+			// all done, CR will be deleted from etcd
 			return ctrl.Result{}, nil
-		}
-		if err := r.ensureFinalizer(log); err != nil {
-			return newRequeueWithDelay(), nil
 		}
 	}
 
@@ -142,9 +143,33 @@ func (r *Reconciler) deleteWatches() error {
 }
 
 // ensureFinalizer ensures that a finalizer exists and updates the CR if it doesn't
-func (r *Reconciler) ensureFinalizer(log vzlog.VerrazzanoLogger) error {
+func (r *Reconciler) ensureFinalizer(log vzlog.VerrazzanoLogger, u *unstructured.Unstructured) error {
+	finalizerName := r.Finalizer.GetName()
+	finalizers := u.GetFinalizers()
+	if vzstring.SliceContainsString(finalizers, finalizerName) {
+		return nil
+	}
 
-	// TODO - must implement
+	log.Oncef("Adding finalizer %s", finalizerName)
+	finalizers = append(finalizers, finalizerName)
+	u.SetFinalizers(finalizers)
+	if err := r.Update(context.TODO(), u); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deleteFinalizer deletes the finalizer
+func (r *Reconciler) deleteFinalizer(log vzlog.VerrazzanoLogger, u *unstructured.Unstructured) error {
+	finalizerName := r.Finalizer.GetName()
+	log.Oncef("Removing finalizer %s", finalizerName)
+	finalizers := vzstring.RemoveStringFromSlice(u.GetFinalizers(), finalizerName)
+	u.SetFinalizers(finalizers)
+	if err := r.Update(context.TODO(), u); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/common/controllers/lifecycle/finalizer.go
+++ b/common/controllers/lifecycle/finalizer.go
@@ -9,7 +9,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-const finalizerName = "modulelifecycle.finalizer.verrazzano.io"
+const finalizerName = "platform.verrazzano.io/modulelifecycle.finalizer"
 
 // GetName returns the name of the finalizer
 func (r Reconciler) GetName() string {
@@ -18,17 +18,5 @@ func (r Reconciler) GetName() string {
 
 // Cleanup garbage collects any related resources that were created by the controller
 func (r Reconciler) Cleanup(spictx spi.ReconcileContext, u *unstructured.Unstructured) (ctrl.Result, error) {
-	//if err := UpdateStatus(r.Client(), mlc, string(modulesv1alpha1.CondUninstall), modulesv1alpha1.CondUninstall); err != nil {
-	//	return ctrl.Result{}, err
-	//}
-	//if err := r.Uninstall(ctx); err != nil {
-	//	return newRequeueWithDelay(), err
-	//}
-	//if err := removeFinalizer(ctx, mlc); err != nil {
-	//	return newRequeueWithDelay(), err
-	//}
-	//ctx.Log().Infof("Uninstall of %s complete", common.GetNamespacedName(mlc.ObjectMeta))
-	//return ctrl.Result{}, nil
-
 	return ctrl.Result{}, nil
 }

--- a/common/controllers/lifecycle/manager.go
+++ b/common/controllers/lifecycle/manager.go
@@ -30,6 +30,7 @@ func InitController(mgr ctrlruntime.Manager, comp compspi.LifecycleComponent, cl
 	// The config MUST contain at least the Reconciler.  Other spi interfaces are optional.
 	config := basecontroller.ControllerConfig{
 		Reconciler: &controller,
+		Finalizer:  &controller,
 	}
 	br, err := basecontroller.InitBaseController(mgr, config, class)
 	if err != nil {


### PR DESCRIPTION
Change common controller to handle the Finalizer interface.  This provides the foundation for adding Finalizer support to lifecycle operators (when they need it)