### PR TITLE
VZ-9379 minimize the number of watchers

### DIFF
--- a/common/controllers/base/basecontroller/manager.go
+++ b/common/controllers/base/basecontroller/manager.go
@@ -36,10 +36,8 @@ type Reconciler struct {
 	Controller controller.Controller
 	ControllerConfig
 	LifecycleClass moduleplatform.LifecycleClassType
-
-	// watcherMap is needed to keep track of which CRs have been initialized
-	// key is the NSN of the Gateway
-	watcherMap map[types.NamespacedName][]*watcher.WatchContext
+	watchersInitialized bool
+	watchContexts []*watcher.WatchContext
 
 	// controllerResources contains a set of CRs for this controller that exist.
 	// It is important that resources get added to this set during the base controller reconcile loop, as
@@ -54,7 +52,6 @@ func InitBaseController(mgr controllerruntime.Manager, controllerConfig Controll
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),
 		ControllerConfig:    controllerConfig,
-		watcherMap:          make(map[types.NamespacedName][]*watcher.WatchContext),
 		LifecycleClass:      class,
 		controllerResources: make(map[types.NamespacedName]bool),
 		mutex:               sync.RWMutex{},

--- a/common/controllers/base/spi/controllerspi.go
+++ b/common/controllers/base/spi/controllerspi.go
@@ -28,8 +28,8 @@ const (
 	Deleted WatchEvent = iota
 )
 
-// WatchedKind described an object being watched
-type WatchedKind struct {
+// WatchDescriptor described an object being watched
+type WatchDescriptor struct {
 	Kind source.Kind
 	FuncShouldReconcile
 }
@@ -51,8 +51,8 @@ type Reconciler interface {
 
 // Watcher is an interface used by controllers that watch resources
 type Watcher interface {
-	// GetWatchedKinds returns the list of object kinds being watched
-	GetWatchedKinds() []WatchedKind
+	// GetWatchDescriptors returns the list of object kinds being watched
+	GetWatchDescriptors() []WatchDescriptor
 }
 
 // Finalizer is an interface used by controllers the use finalizers

--- a/common/controllers/base/watcher/watcher.go
+++ b/common/controllers/base/watcher/watcher.go
@@ -36,10 +36,7 @@ func (w *WatchContext) Watch() error {
 		// a watched resource just got created
 		CreateFunc: func(e event.CreateEvent) bool {
 			w.Log.Infof("Watcher `create` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
-			if !w.shouldReconcile(e.Object, spi.Created) {
-				return false
-			}
-			return true
+			return w.shouldReconcile(e.Object, spi.Created)
 		},
 		// a watched resource just got updated
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -47,18 +44,12 @@ func (w *WatchContext) Watch() error {
 				return false
 			}
 			w.Log.Infof("Watcher `update` event occurred for watched  resource %s/%s", e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
-			if !w.shouldReconcile(e.ObjectNew, spi.Updated) {
-				return false
-			}
-			return true
+			return w.shouldReconcile(e.ObjectNew, spi.Updated)
 		},
 		// a watched resource just got deleted
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			w.Log.Infof("Watcher `delete` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
-			if !w.shouldReconcile(e.Object, spi.Deleted) {
-				return false
-			}
-			return true
+			return w.shouldReconcile(e.Object, spi.Deleted)
 		},
 	}
 	// return a Watch with the predicate that is called in the future when a resource

--- a/common/controllers/lifecycle/manager.go
+++ b/common/controllers/lifecycle/manager.go
@@ -8,10 +8,8 @@ import (
 	spi "github.com/verrazzano/verrazzano-modules/common/controllers/base/spi"
 	compspi "github.com/verrazzano/verrazzano-modules/common/lifecycle-actions/action_spi"
 	moduleplatform "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // Specify the SPI interfaces that this controller implements
@@ -32,7 +30,6 @@ func InitController(mgr ctrlruntime.Manager, comp compspi.LifecycleComponent, cl
 	config := basecontroller.ControllerConfig{
 		Reconciler: &controller,
 		Finalizer:  &controller,
-		Watcher:    &controller,
 	}
 	br, err := basecontroller.InitBaseController(mgr, config, class)
 	if err != nil {
@@ -48,16 +45,4 @@ func InitController(mgr ctrlruntime.Manager, comp compspi.LifecycleComponent, cl
 // GetReconcileObject returns the kind of object being reconciled
 func (r Reconciler) GetReconcileObject() client.Object {
 	return &moduleplatform.ModuleLifecycle{}
-}
-
-// GetWatchedKinds returns the list of object kinds being watched
-func (r Reconciler) GetWatchDescriptors() []spi.WatchDescriptor {
-	return []spi.WatchDescriptor{{
-		Kind:                source.Kind{Type: &corev1.Pod{}},
-		FuncShouldReconcile: shouldReconcile,
-	}}
-}
-
-func shouldReconcile(object client.Object, event spi.WatchEvent) bool {
-	return true
 }

--- a/common/controllers/lifecycle/manager.go
+++ b/common/controllers/lifecycle/manager.go
@@ -8,9 +8,10 @@ import (
 	spi "github.com/verrazzano/verrazzano-modules/common/controllers/base/spi"
 	compspi "github.com/verrazzano/verrazzano-modules/common/lifecycle-actions/action_spi"
 	moduleplatform "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
-
+	corev1 "k8s.io/api/core/v1"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // Specify the SPI interfaces that this controller implements
@@ -31,6 +32,7 @@ func InitController(mgr ctrlruntime.Manager, comp compspi.LifecycleComponent, cl
 	config := basecontroller.ControllerConfig{
 		Reconciler: &controller,
 		Finalizer:  &controller,
+		Watcher:    &controller,
 	}
 	br, err := basecontroller.InitBaseController(mgr, config, class)
 	if err != nil {
@@ -46,4 +48,16 @@ func InitController(mgr ctrlruntime.Manager, comp compspi.LifecycleComponent, cl
 // GetReconcileObject returns the kind of object being reconciled
 func (r Reconciler) GetReconcileObject() client.Object {
 	return &moduleplatform.ModuleLifecycle{}
+}
+
+// GetWatchedKinds returns the list of object kinds being watched
+func (r Reconciler) GetWatchDescriptors() []spi.WatchDescriptor {
+	return []spi.WatchDescriptor{{
+		Kind:                source.Kind{Type: &corev1.Pod{}},
+		FuncShouldReconcile: shouldReconcile,
+	}}
+}
+
+func shouldReconcile(object client.Object, event spi.WatchEvent) bool {
+	return true
 }


### PR DESCRIPTION
Refactor the common controller and watcher code to minimize the number of watches.  There used to be a watchers per instance of a CR.  Now the watchers are shared for all instances of the CRs.