### PR TITLE
VZ-9401 module common controller unit tests

### DIFF
--- a/common/controllers/base/basecontroller/controller.go
+++ b/common/controllers/base/basecontroller/controller.go
@@ -34,7 +34,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if ro == nil {
 		err := errors.New("Failed, Reconciler.GetReconcileObject returns nil")
 		zap.S().Error(err)
-		return util.NewRequeueWithShortDelay(), nil
+		return util.NewRequeueWithShortDelay(), err
 	}
 	gvk, _, err := r.Scheme.ObjectKinds(ro)
 	if err != nil {

--- a/common/controllers/base/basecontroller/controller.go
+++ b/common/controllers/base/basecontroller/controller.go
@@ -27,6 +27,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	gvk, _, err := r.Scheme.ObjectKinds(r.GetReconcileObject())
 	if err != nil {
 		zap.S().Errorf("Failed to get object GVK for %v: %v", r.GetReconcileObject(), err)
+		return util.NewRequeueWithShortDelay(), nil
 	}
 
 	cr.SetGroupVersionKind(gvk[0])
@@ -50,6 +51,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	})
 	if err != nil {
 		zap.S().Errorf("Failed to create controller logger for DNS controller", err)
+		return util.NewRequeueWithShortDelay(), nil
 	}
 
 	log.Progressf("Reconciling resource %v, GVK %v, generation %v", req.NamespacedName, gvk, cr.GetGeneration())

--- a/common/controllers/base/basecontroller/controller.go
+++ b/common/controllers/base/basecontroller/controller.go
@@ -83,7 +83,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 		} else {
 			// CR is being deleted
-			res, err := r.Cleanup(rctx, cr)
+			res, err := r.PreRemoveFinalizer(rctx, cr)
 			if res2 := util.DeriveResult(res, err); res2.Requeue {
 				return res2, nil
 			}
@@ -94,6 +94,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 			// all done, CR will be deleted from etcd
 			log.Oncef("Successfully deleted resource %v, generation %v", req.NamespacedName, cr.GetGeneration())
+			r.PostRemoveFinalizer(rctx, cr)
 			r.removeControllerResource(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}

--- a/common/controllers/base/basecontroller/controller.go
+++ b/common/controllers/base/basecontroller/controller.go
@@ -123,7 +123,7 @@ func (r *Reconciler) initWatches(log vzlog.VerrazzanoLogger, nsn types.Namespace
 		w := &watcher.WatchContext{
 			Controller:                 r.Controller,
 			Log:                        log,
-			ResourceKind:               wds[i].Kind,
+			ResourceKind:               wds[i].WatchKind,
 			ShouldReconcile:            wds[i].FuncShouldReconcile,
 			FuncGetControllerResources: r.GetControllerResources,
 		}

--- a/common/controllers/base/basecontroller/controller.go
+++ b/common/controllers/base/basecontroller/controller.go
@@ -50,7 +50,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			r.removeControllerResource(req.NamespacedName)
 			return reconcile.Result{}, nil
 		}
-		zap.S().Errorf("Failed to fetch DNS resource: %v", err)
+		zap.S().Errorf("Failed to fetch resource %v: %v", req.NamespacedName, err)
 		return util.NewRequeueWithShortDelay(), nil
 	}
 

--- a/common/controllers/base/basecontroller/controller_test.go
+++ b/common/controllers/base/basecontroller/controller_test.go
@@ -39,7 +39,9 @@ type ReconcilerImpl struct {
 type WatcherImpl struct {
 	visited bool
 }
-type FinalizerImpl struct{}
+type FinalizerImpl struct{
+
+}
 
 // TestReconciler tests that the layered controller reconcile method is called
 // GIVEN a controller that implements Reconciler interface
@@ -52,7 +54,7 @@ func TestReconciler(t *testing.T) {
 	config := ControllerConfig{
 		Reconciler: &controller,
 	}
-	cr := newModuleCR(namespace, name)
+	cr := newModuleCR(namespace, name, false)
 	clientBuilder := fakes.NewClientBuilder()
 	c := clientBuilder.WithScheme(newScheme()).WithObjects(cr).Build()
 	r := newReconciler(c, config)
@@ -80,7 +82,7 @@ func TestWatcher(t *testing.T) {
 		Watcher:    &watcher,
 		Reconciler: &reconciler,
 	}
-	cr := newModuleCR(namespace, name)
+	cr := newModuleCR(namespace, name, false)
 	clientBuilder := fakes.NewClientBuilder()
 	c := clientBuilder.WithScheme(newScheme()).WithObjects(cr).Build()
 	r := newReconciler(c, config)
@@ -107,7 +109,7 @@ func TestFinalizer(t *testing.T) {
 		Watcher:    &watcher,
 		Reconciler: &reconciler,
 	}
-	cr := newModuleCR(namespace, name)
+	cr := newModuleCR(namespace, name, true)
 	clientBuilder := fakes.NewClientBuilder()
 	c := clientBuilder.WithScheme(newScheme()).WithObjects(cr).Build()
 	r := newReconciler(c, config)
@@ -130,7 +132,7 @@ func TestReconcilerMissing(t *testing.T) {
 
 	controller := ReconcilerImpl{}
 	config := ControllerConfig{}
-	cr := newModuleCR(namespace, name)
+	cr := newModuleCR(namespace, name, false)
 	clientBuilder := fakes.NewClientBuilder()
 	c := clientBuilder.WithScheme(newScheme()).WithObjects(cr).Build()
 	r := newReconciler(c, config)
@@ -173,7 +175,7 @@ func newRequest(namespace string, name string) ctrl.Request {
 			Name:      name}}
 }
 
-func newModuleCR(namespace string, name string) *moduleapi.Module {
+func newModuleCR(namespace string, name string, deleted bool) *moduleapi.Module {
 	return &moduleapi.Module{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/common/controllers/base/basecontroller/controller_test.go
+++ b/common/controllers/base/basecontroller/controller_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package basecontroller
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano-modules/common/controllers/base/spi"
+	moduleapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakes "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+type LayeredReconciler struct{}
+
+// TestEmptyControllerContig tests that the layered controller reconcile method is called
+// GIVEN a Reconciler
+// WHEN Reconcile is called
+// THEN ensure that the layered controller returns success
+func TestEmptyControllerContig(t *testing.T) {
+	asserts := assert.New(t)
+
+	const namespace = "testns"
+	const name = "test"
+
+	layeredReconciler := LayeredReconciler{}
+	config := ControllerConfig{
+		Reconciler: layeredReconciler,
+	}
+	cr := &moduleapi.Module{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	clientBuilder := fakes.NewClientBuilder()
+	c := clientBuilder.WithScheme(newScheme()).WithObjects(cr).Build()
+	r := newReconciler(c, config)
+
+	request := newRequest(namespace, name)
+	res, err := r.Reconcile(context.TODO(), request)
+
+	// state and gen should never match
+	asserts.NoError(err)
+	asserts.False(res.Requeue)
+}
+
+// newReconciler creates a new reconciler for testing
+func newReconciler(c client.Client, controllerConfig ControllerConfig) Reconciler {
+	scheme := newScheme()
+	reconciler := Reconciler{
+		Client:           c,
+		Scheme:           scheme,
+		ControllerConfig: controllerConfig,
+	}
+	return reconciler
+}
+
+// newScheme creates a new scheme that includes this package's object to use for testing
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = moduleapi.AddToScheme(scheme)
+	return scheme
+}
+
+func newRequest(namespace string, name string) ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      name}}
+}
+
+// GetReconcileObject returns the kind of object being reconciled
+func (r LayeredReconciler) GetReconcileObject() client.Object {
+	return &moduleapi.Module{}
+}
+
+// Reconcile reconciles the ModuleLifecycle CR
+func (r LayeredReconciler) Reconcile(spictx spi.ReconcileContext, u *unstructured.Unstructured) (ctrl.Result, error) {
+	cr := &moduleapi.Module{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, cr); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}

--- a/common/controllers/base/basecontroller/controller_test.go
+++ b/common/controllers/base/basecontroller/controller_test.go
@@ -74,32 +74,6 @@ func TestReconciler(t *testing.T) {
 	asserts.True(controller.getObjectCalled)
 }
 
-// TestFinalizerExists tests that the layered controller ensure finalizer works if finalizer exists
-// GIVEN a controller that implements Reconciler interface
-// WHEN Reconcile is called
-// THEN ensure that the controller returns success and that the Reconcile method is called
-func TestFinalizerExists(t *testing.T) {
-	asserts := assert.New(t)
-
-	controller := ReconcilerImpl{}
-	config := ControllerConfig{
-		Reconciler: &controller,
-	}
-	cr := newModuleCR(namespace, name)
-	clientBuilder := fakes.NewClientBuilder()
-	c := clientBuilder.WithScheme(newScheme()).WithObjects(cr).Build()
-	r := newReconciler(c, config)
-
-	request := newRequest(namespace, name)
-	res, err := r.Reconcile(context.TODO(), request)
-
-	// state and gen should never match
-	asserts.NoError(err)
-	asserts.False(res.Requeue)
-	asserts.True(controller.reconcileCalled)
-	asserts.True(controller.getObjectCalled)
-}
-
 // TestWatcher tests that the layered controller reconcile method is called
 // GIVEN a controller that implements Watcher interface
 // WHEN Reconcile is called

--- a/common/controllers/base/basecontroller/controller_test.go
+++ b/common/controllers/base/basecontroller/controller_test.go
@@ -347,7 +347,7 @@ func TestNotFound(t *testing.T) {
 }
 
 // newReconciler creates a new reconciler for testing
-func newReconciler(c client.Client, controllerConfig ControllerConfig) Reconciler {
+func newReconciler(c client.Client, controllerConfig ControllerConfig) *Reconciler {
 	scheme := newScheme()
 	reconciler := Reconciler{
 		Client:              c,
@@ -356,7 +356,7 @@ func newReconciler(c client.Client, controllerConfig ControllerConfig) Reconcile
 		Controller:          fakeController{},
 		controllerResources: make(map[types.NamespacedName]bool),
 	}
-	return reconciler
+	return &reconciler
 }
 
 // newScheme creates a new scheme that includes this package's object to use for testing

--- a/common/controllers/base/basecontroller/controller_test.go
+++ b/common/controllers/base/basecontroller/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/verrazzano/verrazzano-modules/common/controllers/base/spi"
 	moduleapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -134,6 +135,11 @@ func TestEnsureFinalizer(t *testing.T) {
 	asserts.True(finalizer.getNameCalled)
 	asserts.False(finalizer.preCleanupCalled)
 	asserts.False(finalizer.postCleanupCalled)
+
+	updatedCR := moduleapi.Module{}
+	err = r.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &updatedCR)
+	asserts.NoError(err)
+	asserts.Len(cr.Finalizers, 0)
 }
 
 // TestDelete tests that the layered controller finalizer methods are called
@@ -165,6 +171,10 @@ func TestDelete(t *testing.T) {
 	asserts.True(finalizer.getNameCalled)
 	asserts.True(finalizer.preCleanupCalled)
 	asserts.True(finalizer.postCleanupCalled)
+
+	updatedCR := moduleapi.Module{}
+	err = r.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &updatedCR)
+	asserts.True(errors.IsNotFound(err))
 }
 
 // TestReconcilerMissing tests that an error is returned when the reconciler implementation is missing

--- a/common/controllers/base/spi/controllerspi.go
+++ b/common/controllers/base/spi/controllerspi.go
@@ -30,7 +30,7 @@ const (
 
 // WatchDescriptor described an object being watched
 type WatchDescriptor struct {
-	Kind source.Kind
+	WatchKind source.Kind
 	FuncShouldReconcile
 }
 

--- a/common/controllers/base/spi/controllerspi.go
+++ b/common/controllers/base/spi/controllerspi.go
@@ -60,6 +60,11 @@ type Finalizer interface {
 	// GetName returns the name of the finalizer
 	GetName() string
 
-	// Cleanup garbage collects any related resources that were created by the controller
-	Cleanup(ReconcileContext, *unstructured.Unstructured) (ctrl.Result, error)
+	// PreRemoveFinalizer is called when the resource is being deleted, before the finalizer
+	// is removed.  Use this method to delete Kubernetes resources, etc.
+	PreRemoveFinalizer(ReconcileContext, *unstructured.Unstructured) (ctrl.Result, error)
+
+	// PostRemoveFinalizer is called after the finalizer is successfully removed.
+	// This method does garbage collection and other tasks that can never return an error
+	PostRemoveFinalizer(ReconcileContext, *unstructured.Unstructured)
 }

--- a/common/controllers/modulelifecycle/finalizer.go
+++ b/common/controllers/modulelifecycle/finalizer.go
@@ -16,7 +16,13 @@ func (r Reconciler) GetName() string {
 	return finalizerName
 }
 
-// Cleanup garbage collects any related resources that were created by the controller
-func (r Reconciler) Cleanup(spictx spi.ReconcileContext, u *unstructured.Unstructured) (ctrl.Result, error) {
+// PreRemoveFinalizer is called when the resource is being deleted, before the finalizer
+// is removed.  Use this method to delete Kubernetes resources, etc.
+func (r Reconciler) PreRemoveFinalizer(spictx spi.ReconcileContext, u *unstructured.Unstructured) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
+}
+
+// PostRemoveFinalizer is called after the finalizer is successfully removed.
+// This method does garbage collection and other tasks that can never return an error
+func (r Reconciler) PostRemoveFinalizer(spictx spi.ReconcileContext, u *unstructured.Unstructured) {
 }

--- a/common/controllers/modulelifecycle/manager.go
+++ b/common/controllers/modulelifecycle/manager.go
@@ -44,8 +44,3 @@ func InitController(mgr ctrlruntime.Manager, comp actionspi.ActionHandlers, clas
 	controller.comp = comp
 	return nil
 }
-
-// GetReconcileObject returns the kind of object being reconciled
-func (r Reconciler) GetReconcileObject() client.Object {
-	return &moduleplatform.ModuleLifecycle{}
-}

--- a/common/controllers/modulelifecycle/reconciler.go
+++ b/common/controllers/modulelifecycle/reconciler.go
@@ -14,7 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// GetReconcileObject returns the kind of object being reconciled
+func (r Reconciler) GetReconcileObject() client.Object {
+	return &moduleplatform.ModuleLifecycle{}
+}
 
 // Reconcile reconciles the ModuleLifecycle CR
 func (r Reconciler) Reconcile(spictx spi.ReconcileContext, u *unstructured.Unstructured) (ctrl.Result, error) {

--- a/module-operator/controllers/module/finalizer.go
+++ b/module-operator/controllers/module/finalizer.go
@@ -18,11 +18,17 @@ func (r Reconciler) GetName() string {
 	return finalizerName
 }
 
-// Cleanup uninstalls the module
-func (r Reconciler) Cleanup(spictx spi.ReconcileContext, u *unstructured.Unstructured) (ctrl.Result, error) {
+// PreRemoveFinalizer is called when the resource is being deleted, before the finalizer
+// is removed.  Use this method to delete Kubernetes resources, etc.
+func (r Reconciler) PreRemoveFinalizer(spictx spi.ReconcileContext, u *unstructured.Unstructured) (ctrl.Result, error) {
 	cr := &moduleplatform.Module{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, cr); err != nil {
 		return ctrl.Result{}, err
 	}
 	return r.reconcileAction(spictx, cr, r.comp.UninstallAction)
+}
+
+// PostRemoveFinalizer is called after the finalizer is successfully removed.
+// This method does garbage collection and other tasks that can never return an error
+func (r Reconciler) PostRemoveFinalizer(spictx spi.ReconcileContext, u *unstructured.Unstructured) {
 }


### PR DESCRIPTION
Add module common controller unit tests.
Change Finalizer interface to add postFinalizer garbage collection cleanup.  This is needed for tracker map.