### PR TITLE
Only create namespace when using helm templates

### DIFF
--- a/module-operator/manifests/charts/operators/verrazzano-module-operator/values.yaml
+++ b/module-operator/manifests/charts/operators/verrazzano-module-operator/values.yaml
@@ -7,7 +7,7 @@
 
 replicaCount: 1
 
-createNamespace: true
+createNamespace: false
 namespaceLabelKey: verrazzano.io/namespace
 
 image:

--- a/tools/scripts/generate_operator_artifacts.sh
+++ b/tools/scripts/generate_operator_artifacts.sh
@@ -42,6 +42,7 @@ if [ -n "${IMAGE_PULL_SECRETS}" ] ; then
 fi
 yq -i eval '.image.repository = env(DOCKER_IMAGE_FULLNAME)'  ${TARGET_VALUES}
 yq -i eval '.image.tag = env(DOCKER_IMAGE_TAG)' ${TARGET_VALUES}
+yq -i eval '.createNamespace = true' ${TARGET_VALUES}
 helm package ${TARGET_CHART} -d ${BUILD_OUT}
 
 helm template --include-crds ${TARGET_CHART} -n "verrazzano-install" > ${OPERATOR_YAML}


### PR DESCRIPTION
Do not use the Namespace resource when using helm to install the module-operator chart.  This doesn't work.  The user must create the namespace first or use helm --create-namespace.

The generated verrazzano-module-operator.yaml should have the namespace resource, this works fine when you apply the .yaml since the namespace resource is first in the list.