### PR TITLE
VZ-9686: Use scratch for operator base image

### DIFF
--- a/module-operator/Dockerfile
+++ b/module-operator/Dockerfile
@@ -21,6 +21,7 @@ COPY --from=build_base --chown=1000 /usr/local/bin/verrazzano-module-operator /u
 
 WORKDIR /home/verrazzano
 COPY --from=build_base --chown=1000 /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/manifests ./manifests
+COPY --from=build_base --chown=1000 /tmp /tmp
 #COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000

--- a/module-operator/Dockerfile
+++ b/module-operator/Dockerfile
@@ -14,21 +14,15 @@ COPY bin/linux_amd64/verrazzano-module-operator /usr/local/bin/verrazzano-module
 RUN chmod 500 /usr/local/bin/verrazzano-module-operator
 
 # Create the verrazzano-module-operator image
-FROM $BASE_IMAGE AS final
-
-RUN groupadd -r verrazzano \
-    && useradd --no-log-init -r -m -d /verrazzano -g verrazzano -u 1000 verrazzano \
-    && mkdir /home/verrazzano \
-    && chown -R 1000:verrazzano /home/verrazzano
-
-COPY --from=build_base --chown=verrazzano:verrazzano /usr/local/bin/verrazzano-module-operator /usr/local/bin/verrazzano-module-operator
+FROM scratch AS final
 
 # Copy the operator binary
+COPY --from=build_base --chown=1000 /usr/local/bin/verrazzano-module-operator /usr/local/bin/verrazzano-module-operator
+
 WORKDIR /home/verrazzano
-COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/manifests/config/scripts/run.sh .
-COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/manifests ./manifests
+COPY --from=build_base --chown=1000 /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/manifests ./manifests
 #COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 
-ENTRYPOINT ["/home/verrazzano/run.sh"]
+ENTRYPOINT ["/usr/local/bin/verrazzano-module-operator"]

--- a/module-operator/Makefile
+++ b/module-operator/Makefile
@@ -12,7 +12,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-GO ?= GO111MODULE=on GOPRIVATE=github.com/verrazzano go
+GO ?= CGO_ENABLED=0 GO111MODULE=on GOPRIVATE=github.com/verrazzano go
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/module-operator/manifests/config/scripts/run.sh
+++ b/module-operator/manifests/config/scripts/run.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-#
-# Copyright (c) 2023, Oracle and/or its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-#
-
-# Run the operator
-/usr/local/bin/verrazzano-module-operator $*


### PR DESCRIPTION
I tested this image in a local cluster using the vz-test helm module. I added overrides and verified that they are correctly applied.