### PR TITLE
Revert "VZ-9686: Use scratch for operator base image (#95)"

### DIFF
--- a/module-operator/Dockerfile
+++ b/module-operator/Dockerfile
@@ -14,16 +14,21 @@ COPY bin/linux_amd64/verrazzano-module-operator /usr/local/bin/verrazzano-module
 RUN chmod 500 /usr/local/bin/verrazzano-module-operator
 
 # Create the verrazzano-module-operator image
-FROM scratch AS final
+FROM $BASE_IMAGE AS final
+
+RUN groupadd -r verrazzano \
+    && useradd --no-log-init -r -m -d /verrazzano -g verrazzano -u 1000 verrazzano \
+    && mkdir /home/verrazzano \
+    && chown -R 1000:verrazzano /home/verrazzano
 
 # Copy the operator binary
-COPY --from=build_base --chown=1000 /usr/local/bin/verrazzano-module-operator /usr/local/bin/verrazzano-module-operator
+COPY --from=build_base --chown=verrazzano:verrazzano /usr/local/bin/verrazzano-module-operator /usr/local/bin/verrazzano-module-operator
 
 WORKDIR /home/verrazzano
-COPY --from=build_base --chown=1000 /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/manifests ./manifests
-COPY --from=build_base --chown=1000 /tmp /tmp
-COPY --from=build_base --chown=1000 /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/THIRD_PARTY_LICENSES.txt /licenses/
+COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/manifests/config/scripts/run.sh .
+COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/manifests ./manifests
+COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano-modules/module-operator/THIRD_PARTY_LICENSES.txt /licenses/
 
 USER 1000
 
-ENTRYPOINT ["/usr/local/bin/verrazzano-module-operator"]
+ENTRYPOINT ["/home/verrazzano/run.sh"]

--- a/module-operator/Makefile
+++ b/module-operator/Makefile
@@ -12,7 +12,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-GO ?= CGO_ENABLED=0 GO111MODULE=on GOPRIVATE=github.com/verrazzano go
+GO ?= GO111MODULE=on GOPRIVATE=github.com/verrazzano go
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/module-operator/manifests/config/scripts/run.sh
+++ b/module-operator/manifests/config/scripts/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+# Run the operator
+/usr/local/bin/verrazzano-module-operator $*


### PR DESCRIPTION
This reverts commit 8e44400f0fd4bad716377384ca7c250bff4b7585.

This PR preserves the change to copy the THIRD_PARTY_LICENSES.txt file to the resulting image.