### PR TITLE
VZ-9801: add deployment to vz-test

### DIFF
--- a/module-operator/manifests/charts/vz-test/0.1.0/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.0/templates/deployment.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   name: vz-test-nginx
 spec:
-  replicas: { { .Values.deployment.replicas } }
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       app: vz-test

--- a/module-operator/manifests/charts/vz-test/0.1.0/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.0/templates/deployment.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/module-operator/manifests/charts/vz-test/0.1.0/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.0/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vz-test-nginx
+spec:
+  replicas: { { .Values.deployment.replicas } }
+  selector:
+    matchLabels:
+      app: vz-test
+  template:
+    metadata:
+      labels:
+        app: vz-test
+    spec:
+      containers:
+        - name: nginx
+          image: ghcr.io/oracle/oraclelinux8-nginx:latest
+          command:
+            [
+              "/bin/sh",
+              "-ec",
+              'x=1; while  [ $x -le {{ .Values.deployment.delaySeconds }} ]; do echo "$x" $(( x++ )); sleep 1; done; nginx -g "daemon off;"',
+            ]
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3

--- a/module-operator/manifests/charts/vz-test/0.1.0/values.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.0/values.yaml
@@ -1,3 +1,6 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 files: {}
+deployment:
+  replicas: 1
+  delaySeconds: 2

--- a/module-operator/manifests/charts/vz-test/0.1.1/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.1/templates/deployment.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   name: vz-test-nginx
 spec:
-  replicas: { { .Values.deployment.replicas } }
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       app: vz-test

--- a/module-operator/manifests/charts/vz-test/0.1.1/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.1/templates/deployment.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/module-operator/manifests/charts/vz-test/0.1.1/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.1/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vz-test-nginx
+spec:
+  replicas: { { .Values.deployment.replicas } }
+  selector:
+    matchLabels:
+      app: vz-test
+  template:
+    metadata:
+      labels:
+        app: vz-test
+    spec:
+      containers:
+        - name: nginx
+          image: ghcr.io/oracle/oraclelinux8-nginx:latest
+          command:
+            [
+              "/bin/sh",
+              "-ec",
+              'x=1; while  [ $x -le {{ .Values.deployment.delaySeconds }} ]; do echo "$x" $(( x++ )); sleep 1; done; nginx -g "daemon off;"',
+            ]
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3

--- a/module-operator/manifests/charts/vz-test/0.1.1/values.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.1/values.yaml
@@ -3,3 +3,6 @@
 files: {}
 variables:
   var1: "var1"
+deployment:
+  replicas: 2
+  delaySeconds: 2

--- a/module-operator/manifests/charts/vz-test/0.1.2/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.2/templates/deployment.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   name: vz-test-nginx
 spec:
-  replicas: { { .Values.deployment.replicas } }
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       app: vz-test

--- a/module-operator/manifests/charts/vz-test/0.1.2/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.2/templates/deployment.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/module-operator/manifests/charts/vz-test/0.1.2/templates/deployment.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.2/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vz-test-nginx
+spec:
+  replicas: { { .Values.deployment.replicas } }
+  selector:
+    matchLabels:
+      app: vz-test
+  template:
+    metadata:
+      labels:
+        app: vz-test
+    spec:
+      containers:
+        - name: nginx
+          image: ghcr.io/oracle/oraclelinux8-nginx:latest
+          command:
+            [
+              "/bin/sh",
+              "-ec",
+              'x=1; while  [ $x -le {{ .Values.deployment.delaySeconds }} ]; do echo "$x" $(( x++ )); sleep 1; done; nginx -g "daemon off;"',
+            ]
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3

--- a/module-operator/manifests/charts/vz-test/0.1.2/values.yaml
+++ b/module-operator/manifests/charts/vz-test/0.1.2/values.yaml
@@ -4,3 +4,6 @@ files: {}
 variables:
   var1: "var1"
   var2: "var2"
+deployment:
+  replicas: 3
+  delaySeconds: 2

--- a/tests/modules/helm/lifecycle/lifecycle_suite_test.go
+++ b/tests/modules/helm/lifecycle/lifecycle_suite_test.go
@@ -127,6 +127,8 @@ func (suite *HelmModuleLifecycleTestSuite) createOrUpdateModule(logger testLogge
 	op := "create"
 	if update {
 		op = "update"
+		module, err = c.Modules(module.GetNamespace()).Get(context.TODO(), module.GetName(), v1.GetOptions{})
+		suite.gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
 	logger.log("%s module %s, version %s, namespace %s", op, module.GetName(), module.Spec.Version, module.GetNamespace())


### PR DESCRIPTION
added nginx deployment to vz-test `.Values.deployment.delaySeconds` can be overridden to induce delay for interrupt tests
fixed an issue when parallel tests were resulting in intermittent `Operation not permitted` error on module update by updating the latest