### PR TITLE
Create Module targetNamespace if it does not exist

### DIFF
--- a/module-operator/controllers/module/handlers/helm/install/install_handler_test.go
+++ b/module-operator/controllers/module/handlers/helm/install/install_handler_test.go
@@ -120,11 +120,15 @@ func TestPreWork(t *testing.T) {
 	// GIVEN an install handler and a Module with an empty version
 	// WHEN the PreWork function is called
 	// THEN no error occurs and the function returns a ctrl.Result for requeue and the Module spec version
-	// has been set
+	// has been set and the Module target namespace has been created
+	const targetNamespace = "target-namespace"
 	module := &v1alpha1.Module{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      moduleName,
 			Namespace: namespace,
+		},
+		Spec: v1alpha1.ModuleSpec{
+			TargetNamespace: targetNamespace,
 		},
 	}
 
@@ -157,6 +161,11 @@ func TestPreWork(t *testing.T) {
 	err = cli.Get(context.TODO(), types.NamespacedName{Name: moduleName, Namespace: namespace}, module)
 	asserts.NoError(err)
 	asserts.Equal(chartVersion, module.Spec.Version)
+
+	// validate that the namespace was created
+	ns := &corev1.Namespace{}
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: targetNamespace}, ns)
+	asserts.NoError(err)
 
 	// GIVEN an install handler and a Module with a version set
 	// WHEN the PreWork function is called

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -10,8 +10,10 @@ const GlobalImagePullSecName = "verrazzano-container-registry"
 type ComponentAvailability string
 
 const (
-	//ComponentAvailable signifies that a Component is ready for use.
+	// ComponentAvailable signifies that a Component is ready for use.
 	ComponentAvailable = "Available"
-	//ComponentUnavailable signifies that a Verrazzano Component is not ready for use.
+	// ComponentUnavailable signifies that a Verrazzano Component is not ready for use.
 	ComponentUnavailable = "Unavailable"
+	// VerrazzanoNamespaceLabel is the label used to indicate a Verrazzano namespace
+	VerrazzanoNamespaceLabel = "verrazzano.io/namespace"
 )


### PR DESCRIPTION
Tested this in a local cluster and verified that the namespace is created and labeled correctly.