### PR TITLE
Removing leading space from helm key constant

### DIFF
--- a/module-operator/controllers/module/handlers/common/workloads_ready.go
+++ b/module-operator/controllers/module/handlers/common/workloads_ready.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"context"
+
 	"github.com/verrazzano/verrazzano-modules/module-operator/internal/handlerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/k8s/readiness"
 	v1 "k8s.io/api/apps/v1"
@@ -12,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const helmKey = " meta.helm.sh/release-name"
+const helmKey = "meta.helm.sh/release-name"
 
 // CheckWorkLoadsReady checks to see if the workloads used by the Helm release are ready.
 func CheckWorkLoadsReady(ctx handlerspi.HandlerContext, releaseName string, namespace string) (bool, error) {


### PR DESCRIPTION
The workload readiness checks are not working correctly. The problem is that we look for a helm annotation and the annotation key has a leading space.