### PR TITLE
Fix handler API to be immutable

### DIFF
--- a/module-operator/controllers/module/finalizer_test.go
+++ b/module-operator/controllers/module/finalizer_test.go
@@ -179,10 +179,6 @@ func (h finalizerHandler) GetWorkName() string {
 	return "install"
 }
 
-func (h finalizerHandler) Init(context handlerspi.HandlerContext, config handlerspi.StateMachineHandlerConfig) (ctrl.Result, error) {
-	return ctrl.Result{}, nil
-}
-
 func (h finalizerHandler) IsWorkNeeded(context handlerspi.HandlerContext) (bool, ctrl.Result, error) {
 	return true, ctrl.Result{}, nil
 }

--- a/module-operator/controllers/module/handlers/common/base_handler.go
+++ b/module-operator/controllers/module/handlers/common/base_handler.go
@@ -8,7 +8,6 @@ import (
 
 	moduleapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
 	"github.com/verrazzano/verrazzano-modules/module-operator/internal/handlerspi"
-	"github.com/verrazzano/verrazzano-modules/pkg/constants"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/util"
 	helm2 "github.com/verrazzano/verrazzano-modules/pkg/helm"
 	"github.com/verrazzano/verrazzano-modules/pkg/vzlog"
@@ -21,19 +20,7 @@ type upgradeFuncSig func(log vzlog.VerrazzanoLogger, releaseOpts *helm2.HelmRele
 
 var upgradeFunc upgradeFuncSig = helm2.UpgradeRelease
 
-type BaseHandler struct {
-	// Config is the handler configuration
-	Config handlerspi.StateMachineHandlerConfig
-
-	// HelmInfo has the helm information
-	handlerspi.HelmInfo
-
-	// ModuleCR is the Module CR being handled
-	ModuleCR *moduleapi.Module
-
-	// ImagePullSecretKeyname is the Helm Value Key for the image pull secret for a chart
-	ImagePullSecretKeyname string
-}
+type BaseHandler struct{}
 
 func SetUpgradeFunc(f upgradeFuncSig) {
 	upgradeFunc = f
@@ -43,20 +30,12 @@ func ResetUpgradeFunc() {
 	upgradeFunc = helm2.UpgradeRelease
 }
 
-// Init initializes the handler with Helm chart information
-func (h *BaseHandler) InitHandler(_ handlerspi.HandlerContext, config handlerspi.StateMachineHandlerConfig) (ctrl.Result, error) {
-	h.Config = config
-	h.HelmInfo = config.HelmInfo
-	h.ImagePullSecretKeyname = constants.GlobalImagePullSecName
-	h.ModuleCR = config.CR.(*moduleapi.Module)
-	return ctrl.Result{}, nil
-}
-
 // UpdateStatus does the lifecycle pre-Work status update
 func (h BaseHandler) UpdateStatus(ctx handlerspi.HandlerContext, cond moduleapi.LifecycleCondition, state moduleapi.ModuleStateType) (ctrl.Result, error) {
-	AppendCondition(h.ModuleCR, string(cond), cond)
-	h.ModuleCR.Status.State = state
-	if err := ctx.Client.Status().Update(context.TODO(), h.ModuleCR); err != nil {
+	module := ctx.CR.(*moduleapi.Module)
+	AppendCondition(module, string(cond), cond)
+	module.Status.State = state
+	if err := ctx.Client.Status().Update(context.TODO(), module); err != nil {
 		return util.NewRequeueWithShortDelay(), nil
 	}
 	return ctrl.Result{}, nil
@@ -64,13 +43,15 @@ func (h BaseHandler) UpdateStatus(ctx handlerspi.HandlerContext, cond moduleapi.
 
 // UpdateDoneStatus does the lifecycle status update when the work is done
 func (h BaseHandler) UpdateDoneStatus(ctx handlerspi.HandlerContext, cond moduleapi.LifecycleCondition, state moduleapi.ModuleStateType, version string) (ctrl.Result, error) {
-	AppendCondition(h.ModuleCR, string(cond), cond)
-	h.ModuleCR.Status.State = state
-	h.ModuleCR.Status.ObservedGeneration = h.ModuleCR.Generation
+	module := ctx.CR.(*moduleapi.Module)
+
+	AppendCondition(module, string(cond), cond)
+	module.Status.State = state
+	module.Status.ObservedGeneration = module.Generation
 	if len(version) > 0 {
-		h.ModuleCR.Status.Version = version
+		module.Status.Version = version
 	}
-	if err := ctx.Client.Status().Update(context.TODO(), h.ModuleCR); err != nil {
+	if err := ctx.Client.Status().Update(context.TODO(), module); err != nil {
 		return util.NewRequeueWithShortDelay(), nil
 	}
 	return ctrl.Result{}, nil
@@ -78,9 +59,11 @@ func (h BaseHandler) UpdateDoneStatus(ctx handlerspi.HandlerContext, cond module
 
 // HelmUpgradeOrInstall does a Helm upgrade --install of the chart
 func (h BaseHandler) HelmUpgradeOrInstall(ctx handlerspi.HandlerContext) (ctrl.Result, error) {
+	module := ctx.CR.(*moduleapi.Module)
+
 	// Perform a Helm install using the helm upgrade --install command
-	helmRelease := h.Config.HelmInfo.HelmRelease
-	helmOverrides, err := helm2.LoadOverrideFiles(ctx.Log, ctx.Client, helmRelease.Name, h.ModuleCR.Namespace, h.ModuleCR.Spec.Overrides)
+	helmRelease := ctx.HelmInfo.HelmRelease
+	helmOverrides, err := helm2.LoadOverrideFiles(ctx.Log, ctx.Client, helmRelease.Name, module.Namespace, module.Spec.Overrides)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -99,11 +82,11 @@ func (h BaseHandler) HelmUpgradeOrInstall(ctx handlerspi.HandlerContext) (ctrl.R
 // CheckReleaseDeployedAndReady checks if the Helm release is deployed and ready
 func (h BaseHandler) CheckReleaseDeployedAndReady(ctx handlerspi.HandlerContext) (bool, ctrl.Result, error) {
 	if ctx.DryRun {
-		ctx.Log.Debugf("IsReady() dry run for %s", h.HelmRelease.Name)
+		ctx.Log.Debugf("IsReady() dry run for %s", ctx.HelmRelease.Name)
 		return true, ctrl.Result{}, nil
 	}
 	// Check if the Helm release is deployed
-	deployed, err := helm2.IsReleaseDeployed(h.HelmRelease.Name, h.HelmRelease.Namespace)
+	deployed, err := helm2.IsReleaseDeployed(ctx.HelmRelease.Name, ctx.HelmRelease.Namespace)
 	if err != nil {
 		ctx.Log.ErrorfThrottled("Error occurred checking release deployment: %v", err.Error())
 		return false, ctrl.Result{}, err
@@ -113,6 +96,6 @@ func (h BaseHandler) CheckReleaseDeployedAndReady(ctx handlerspi.HandlerContext)
 	}
 
 	// Check if the workload pods are ready
-	ready, err := CheckWorkLoadsReady(ctx, h.HelmRelease.Name, h.HelmRelease.Namespace)
+	ready, err := CheckWorkLoadsReady(ctx, ctx.HelmRelease.Name, ctx.HelmRelease.Namespace)
 	return ready, ctrl.Result{}, err
 }

--- a/module-operator/controllers/module/handlers/helm/delete/delete_handler.go
+++ b/module-operator/controllers/module/handlers/helm/delete/delete_handler.go
@@ -23,11 +23,6 @@ func NewHandler() handlerspi.StateMachineHandler {
 	return &HelmHandler{}
 }
 
-// Init initializes the handler with Helm chart information
-func (h *HelmHandler) Init(ctx handlerspi.HandlerContext, config handlerspi.StateMachineHandlerConfig) (ctrl.Result, error) {
-	return h.BaseHandler.InitHandler(ctx, config)
-}
-
 // GetWorkName returns the work name
 func (h HelmHandler) GetWorkName() string {
 	return "uninstall"
@@ -54,30 +49,30 @@ func (h HelmHandler) DoWorkUpdateStatus(ctx handlerspi.HandlerContext) (ctrl.Res
 }
 
 // DoWork uninstalls the module using Helm
-func (h HelmHandler) DoWork(context handlerspi.HandlerContext) (ctrl.Result, error) {
-	installed, err := helm.IsReleaseInstalled(h.HelmRelease.Name, h.HelmRelease.Namespace)
+func (h HelmHandler) DoWork(ctx handlerspi.HandlerContext) (ctrl.Result, error) {
+	installed, err := helm.IsReleaseInstalled(ctx.HelmRelease.Name, ctx.HelmRelease.Namespace)
 	if err != nil {
-		context.Log.ErrorfThrottled("Error checking if Helm release installed for %s/%s", h.HelmRelease.Namespace, h.HelmRelease.Name)
+		ctx.Log.ErrorfThrottled("Error checking if Helm release installed for %s/%s", ctx.HelmRelease.Namespace, ctx.HelmRelease.Name)
 		return ctrl.Result{}, err
 	}
 	if !installed {
 		return ctrl.Result{}, err
 	}
 
-	err = helm.Uninstall(context.Log, h.HelmRelease.Name, h.HelmRelease.Namespace, context.DryRun)
+	err = helm.Uninstall(ctx.Log, ctx.HelmRelease.Name, ctx.HelmRelease.Namespace, ctx.DryRun)
 	return ctrl.Result{}, err
 }
 
 // IsWorkDone Indicates whether a module is uninstalled
-func (h HelmHandler) IsWorkDone(context handlerspi.HandlerContext) (bool, ctrl.Result, error) {
-	if context.DryRun {
-		context.Log.Debugf("IsReady() dry run for %s", h.HelmRelease.Name)
+func (h HelmHandler) IsWorkDone(ctx handlerspi.HandlerContext) (bool, ctrl.Result, error) {
+	if ctx.DryRun {
+		ctx.Log.Debugf("IsReady() dry run for %s", ctx.HelmRelease.Name)
 		return true, ctrl.Result{}, nil
 	}
 
-	deployed, err := helm.IsReleaseDeployed(h.HelmRelease.Name, h.HelmRelease.Namespace)
+	deployed, err := helm.IsReleaseDeployed(ctx.HelmRelease.Name, ctx.HelmRelease.Namespace)
 	if err != nil {
-		context.Log.ErrorfThrottled("Error occurred checking release deployment: %v", err.Error())
+		ctx.Log.ErrorfThrottled("Error occurred checking release deployment: %v", err.Error())
 		return false, ctrl.Result{}, err
 	}
 

--- a/module-operator/controllers/module/handlers/helm/delete/delete_handler_test.go
+++ b/module-operator/controllers/module/handlers/helm/delete/delete_handler_test.go
@@ -33,20 +33,6 @@ const (
 	moduleName  = "test-module"
 )
 
-// TestInit tests the delete handler Init function
-func TestInit(t *testing.T) {
-	asserts := assert.New(t)
-	handler := NewHandler()
-
-	// GIVEN a delete handler
-	// WHEN the Init function is called
-	// THEN no error occurs and the function returns an empty ctrl.Result
-	config := handlerspi.StateMachineHandlerConfig{CR: &v1alpha1.Module{}}
-	result, err := handler.Init(handlerspi.HandlerContext{}, config)
-	asserts.NoError(err)
-	asserts.Equal(ctrl.Result{}, result)
-}
-
 // TestGetWorkName tests the delete handler GetWorkName function
 func TestGetWorkName(t *testing.T) {
 	asserts := assert.New(t)
@@ -93,12 +79,8 @@ func TestPreWorkUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.PreWorkUpdateStatus(ctx)
 	asserts.NoError(err)
@@ -144,12 +126,8 @@ func TestDoWorkUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.DoWorkUpdateStatus(ctx)
 	asserts.NoError(err)
@@ -222,11 +200,7 @@ func TestDoWork(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -234,8 +208,6 @@ func TestDoWork(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.DoWork(ctx)
 	asserts.NoError(err)
@@ -266,20 +238,14 @@ func TestIsWorkDone(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
 				Namespace: namespace,
 			},
 		},
+		CR: &v1alpha1.Module{},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	done, result, err := handler.IsWorkDone(ctx)
 	asserts.NoError(err)
@@ -345,12 +311,8 @@ func TestWorkCompletedUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.WorkCompletedUpdateStatus(ctx)
 	asserts.NoError(err)

--- a/module-operator/controllers/module/handlers/helm/install/install_handler.go
+++ b/module-operator/controllers/module/handlers/helm/install/install_handler.go
@@ -31,11 +31,6 @@ func NewHandler() handlerspi.StateMachineHandler {
 	return &HelmHandler{}
 }
 
-// Init initializes the handler with Helm chart information
-func (h *HelmHandler) Init(ctx handlerspi.HandlerContext, config handlerspi.StateMachineHandlerConfig) (ctrl.Result, error) {
-	return h.BaseHandler.InitHandler(ctx, config)
-}
-
 // GetWorkName returns the work name
 func (h HelmHandler) GetWorkName() string {
 	return "install"
@@ -53,9 +48,11 @@ func (h HelmHandler) PreWorkUpdateStatus(ctx handlerspi.HandlerContext) (ctrl.Re
 
 // PreWork does the pre-work
 func (h HelmHandler) PreWork(ctx handlerspi.HandlerContext) (ctrl.Result, error) {
+	module := ctx.CR.(*moduleapi.Module)
+
 	// Create the target namespace (if it doesn't exist) and label it
-	if h.ModuleCR.Spec.TargetNamespace != "" {
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: h.ModuleCR.Spec.TargetNamespace}}
+	if module.Spec.TargetNamespace != "" {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: module.Spec.TargetNamespace}}
 		_, err := controllerruntime.CreateOrUpdate(context.TODO(), ctx.Client, ns,
 			func() error {
 				if ns.Labels == nil {
@@ -71,10 +68,10 @@ func (h HelmHandler) PreWork(ctx handlerspi.HandlerContext) (ctrl.Result, error)
 	}
 
 	// Update the spec version if it is not set
-	if len(h.ModuleCR.Spec.Version) == 0 {
+	if len(module.Spec.Version) == 0 {
 		// Update spec version to match chart, always requeue to get ModuleCR with version
-		h.ModuleCR.Spec.Version = h.Config.ChartInfo.Version
-		if err := ctx.Client.Update(context.TODO(), h.ModuleCR); err != nil {
+		module.Spec.Version = ctx.ChartInfo.Version
+		if err := ctx.Client.Update(context.TODO(), module); err != nil {
 			return util.NewRequeueWithShortDelay(), nil
 		}
 		// ALways reconcile so that we get a new tracker with the latest ModuleCR
@@ -91,9 +88,9 @@ func (h HelmHandler) DoWorkUpdateStatus(ctx handlerspi.HandlerContext) (ctrl.Res
 
 // DoWork installs the module using Helm
 func (h HelmHandler) DoWork(ctx handlerspi.HandlerContext) (ctrl.Result, error) {
-	installed, err := helm2.IsReleaseInstalled(h.HelmRelease.Name, h.HelmRelease.Namespace)
+	installed, err := helm2.IsReleaseInstalled(ctx.HelmRelease.Name, ctx.HelmRelease.Namespace)
 	if err != nil {
-		ctx.Log.ErrorfThrottled("Failed checking if Helm release installed for %s/%s: %v", h.HelmRelease.Namespace, h.HelmRelease.Name, err)
+		ctx.Log.ErrorfThrottled("Failed checking if Helm release installed for %s/%s: %v", ctx.HelmRelease.Namespace, ctx.HelmRelease.Name, err)
 		return ctrl.Result{}, err
 	}
 	if installed {
@@ -119,5 +116,7 @@ func (h HelmHandler) PostWork(ctx handlerspi.HandlerContext) (ctrl.Result, error
 
 // WorkCompletedUpdateStatus updates the status to completed
 func (h HelmHandler) WorkCompletedUpdateStatus(ctx handlerspi.HandlerContext) (ctrl.Result, error) {
-	return h.BaseHandler.UpdateDoneStatus(ctx, moduleapi.CondInstallComplete, moduleapi.ModuleStateReady, h.ModuleCR.Spec.Version)
+	module := ctx.CR.(*moduleapi.Module)
+
+	return h.BaseHandler.UpdateDoneStatus(ctx, moduleapi.CondInstallComplete, moduleapi.ModuleStateReady, module.Spec.Version)
 }

--- a/module-operator/controllers/module/handlers/helm/install/install_handler_test.go
+++ b/module-operator/controllers/module/handlers/helm/install/install_handler_test.go
@@ -34,20 +34,6 @@ const (
 	moduleName  = "test-module"
 )
 
-// TestInit tests the install handler Init function
-func TestInit(t *testing.T) {
-	asserts := assert.New(t)
-	handler := NewHandler()
-
-	// GIVEN an install handler
-	// WHEN the Init function is called
-	// THEN no error occurs and the function returns an empty ctrl.Result
-	config := handlerspi.StateMachineHandlerConfig{CR: &v1alpha1.Module{}}
-	result, err := handler.Init(handlerspi.HandlerContext{}, config)
-	asserts.NoError(err)
-	asserts.Equal(ctrl.Result{}, result)
-}
-
 // TestGetWorkName tests the install handler GetWorkName function
 func TestGetWorkName(t *testing.T) {
 	asserts := assert.New(t)
@@ -94,12 +80,8 @@ func TestPreWorkUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.PreWorkUpdateStatus(ctx)
 	asserts.NoError(err)
@@ -133,15 +115,11 @@ func TestPreWork(t *testing.T) {
 	}
 
 	cli := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(module).Build()
+	const chartVersion = "1.2.3"
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Module and Helm release info are set in the base handler
-	const chartVersion = "1.2.3"
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: module,
+		CR:     module,
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				ChartInfo: handlerspi.HelmChart{
@@ -150,8 +128,6 @@ func TestPreWork(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.PreWork(ctx)
 	asserts.NoError(err)
@@ -195,12 +171,8 @@ func TestDoWorkUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.DoWorkUpdateStatus(ctx)
 	asserts.NoError(err)
@@ -273,11 +245,7 @@ func TestDoWork(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -285,8 +253,6 @@ func TestDoWork(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.DoWork(ctx)
 	asserts.NoError(err)
@@ -324,11 +290,7 @@ func TestIsWorkDone(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -336,8 +298,6 @@ func TestIsWorkDone(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	done, result, err := handler.IsWorkDone(ctx)
 	asserts.NoError(err)
@@ -393,12 +353,8 @@ func TestWorkCompletedUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.WorkCompletedUpdateStatus(ctx)
 	asserts.NoError(err)

--- a/module-operator/controllers/module/handlers/helm/update/update_handler.go
+++ b/module-operator/controllers/module/handlers/helm/update/update_handler.go
@@ -23,11 +23,6 @@ func NewHandler() handlerspi.StateMachineHandler {
 	return &HelmHandler{}
 }
 
-// Init initializes the handler with Helm chart information
-func (h *HelmHandler) Init(ctx handlerspi.HandlerContext, config handlerspi.StateMachineHandlerConfig) (ctrl.Result, error) {
-	return h.BaseHandler.InitHandler(ctx, config)
-}
-
 // GetWorkName returns the work name
 func (h HelmHandler) GetWorkName() string {
 	return "update"
@@ -35,9 +30,11 @@ func (h HelmHandler) GetWorkName() string {
 
 // IsWorkNeeded returns true if update is needed
 func (h HelmHandler) IsWorkNeeded(ctx handlerspi.HandlerContext) (bool, ctrl.Result, error) {
-	installed, err := helm2.IsReleaseInstalled(h.HelmRelease.Name, h.BaseHandler.Config.Namespace)
+	module := ctx.CR.(*moduleapi.Module)
+
+	installed, err := helm2.IsReleaseInstalled(ctx.HelmRelease.Name, module.Spec.TargetNamespace)
 	if err != nil {
-		ctx.Log.ErrorfThrottled("Error checking if Helm release installed for %s/%s", h.HelmRelease.Namespace, h.HelmRelease.Name)
+		ctx.Log.ErrorfThrottled("Error checking if Helm release installed for %s/%s", ctx.HelmRelease.Namespace, ctx.HelmRelease.Name)
 		return true, ctrl.Result{}, err
 	}
 	return installed, ctrl.Result{}, err

--- a/module-operator/controllers/module/handlers/helm/update/update_handler_test.go
+++ b/module-operator/controllers/module/handlers/helm/update/update_handler_test.go
@@ -34,20 +34,6 @@ const (
 	moduleName  = "test-module"
 )
 
-// TestInit tests the update handler Init function
-func TestInit(t *testing.T) {
-	asserts := assert.New(t)
-	handler := NewHandler()
-
-	// GIVEN an update handler
-	// WHEN the Init function is called
-	// THEN no error occurs and the function returns an empty ctrl.Result
-	config := handlerspi.StateMachineHandlerConfig{CR: &v1alpha1.Module{}}
-	result, err := handler.Init(handlerspi.HandlerContext{}, config)
-	asserts.NoError(err)
-	asserts.Equal(ctrl.Result{}, result)
-}
-
 // TestGetWorkName tests the update handler GetWorkName function
 func TestGetWorkName(t *testing.T) {
 	asserts := assert.New(t)
@@ -80,12 +66,8 @@ func TestPreWorkUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.PreWorkUpdateStatus(ctx)
 	asserts.NoError(err)
@@ -131,12 +113,8 @@ func TestDoWorkUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.DoWorkUpdateStatus(ctx)
 	asserts.NoError(err)
@@ -206,11 +184,7 @@ func TestDoWork(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -218,8 +192,6 @@ func TestDoWork(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	var upgradeFuncCalled = false
 	common.SetUpgradeFunc(func(log vzlog.VerrazzanoLogger, releaseOpts *vzhelm.HelmReleaseOpts, wait bool, dryRun bool) (*release.Release, error) {
@@ -250,11 +222,7 @@ func TestIsWorkDone(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -262,8 +230,6 @@ func TestIsWorkDone(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	done, result, err := handler.IsWorkDone(ctx)
 	asserts.NoError(err)
@@ -287,11 +253,7 @@ func TestIsWorkNeeded(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -299,8 +261,6 @@ func TestIsWorkNeeded(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	needed, result, err := handler.IsWorkNeeded(ctx)
 	asserts.NoError(err)
@@ -366,12 +326,8 @@ func TestWorkCompletedUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.WorkCompletedUpdateStatus(ctx)
 	asserts.NoError(err)

--- a/module-operator/controllers/module/handlers/helm/upgrade/upgrade_handler.go
+++ b/module-operator/controllers/module/handlers/helm/upgrade/upgrade_handler.go
@@ -23,11 +23,6 @@ func NewHandler() handlerspi.StateMachineHandler {
 	return &HelmHandler{}
 }
 
-// Init initializes the handler with Helm chart information
-func (h *HelmHandler) Init(ctx handlerspi.HandlerContext, config handlerspi.StateMachineHandlerConfig) (ctrl.Result, error) {
-	return h.BaseHandler.InitHandler(ctx, config)
-}
-
 // GetWorkName returns the work name
 func (h HelmHandler) GetWorkName() string {
 	return "upgrade"
@@ -35,9 +30,11 @@ func (h HelmHandler) GetWorkName() string {
 
 // IsWorkNeeded returns true if upgrade is needed
 func (h HelmHandler) IsWorkNeeded(ctx handlerspi.HandlerContext) (bool, ctrl.Result, error) {
-	installed, err := helm2.IsReleaseInstalled(h.HelmRelease.Name, h.BaseHandler.Config.Namespace)
+	module := ctx.CR.(*moduleapi.Module)
+
+	installed, err := helm2.IsReleaseInstalled(ctx.HelmRelease.Name, module.Spec.TargetNamespace)
 	if err != nil {
-		ctx.Log.ErrorfThrottled("Error checking if Helm release installed for %s/%s", h.HelmRelease.Namespace, h.HelmRelease.Name)
+		ctx.Log.ErrorfThrottled("Error checking if Helm release installed for %s/%s", ctx.HelmRelease.Namespace, ctx.HelmRelease.Name)
 		return true, ctrl.Result{}, err
 	}
 	return installed, ctrl.Result{}, err
@@ -80,5 +77,6 @@ func (h HelmHandler) PostWork(ctx handlerspi.HandlerContext) (ctrl.Result, error
 
 // WorkCompletedUpdateStatus updates the status to completed
 func (h HelmHandler) WorkCompletedUpdateStatus(ctx handlerspi.HandlerContext) (ctrl.Result, error) {
-	return h.BaseHandler.UpdateDoneStatus(ctx, moduleapi.CondUpgradeComplete, moduleapi.ModuleStateReady, h.ModuleCR.Spec.Version)
+	module := ctx.CR.(*moduleapi.Module)
+	return h.BaseHandler.UpdateDoneStatus(ctx, moduleapi.CondUpgradeComplete, moduleapi.ModuleStateReady, module.Spec.Version)
 }

--- a/module-operator/controllers/module/handlers/helm/upgrade/upgrade_handler_test.go
+++ b/module-operator/controllers/module/handlers/helm/upgrade/upgrade_handler_test.go
@@ -34,20 +34,6 @@ const (
 	moduleName  = "test-module"
 )
 
-// TestInit tests the upgrade handler Init function
-func TestInit(t *testing.T) {
-	asserts := assert.New(t)
-	handler := NewHandler()
-
-	// GIVEN an upgrade handler
-	// WHEN the Init function is called
-	// THEN no error occurs and the function returns an empty ctrl.Result
-	config := handlerspi.StateMachineHandlerConfig{CR: &v1alpha1.Module{}}
-	result, err := handler.Init(handlerspi.HandlerContext{}, config)
-	asserts.NoError(err)
-	asserts.Equal(ctrl.Result{}, result)
-}
-
 // TestGetWorkName tests the upgrade handler GetWorkName function
 func TestGetWorkName(t *testing.T) {
 	asserts := assert.New(t)
@@ -80,12 +66,8 @@ func TestPreWorkUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.PreWorkUpdateStatus(ctx)
 	asserts.NoError(err)
@@ -131,12 +113,8 @@ func TestDoWorkUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.DoWorkUpdateStatus(ctx)
 	asserts.NoError(err)
@@ -206,11 +184,7 @@ func TestDoWork(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -218,8 +192,6 @@ func TestDoWork(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	var upgradeFuncCalled = false
 	common.SetUpgradeFunc(func(log vzlog.VerrazzanoLogger, releaseOpts *vzhelm.HelmReleaseOpts, wait bool, dryRun bool) (*release.Release, error) {
@@ -250,11 +222,7 @@ func TestIsWorkDone(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -262,8 +230,6 @@ func TestIsWorkDone(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	done, result, err := handler.IsWorkDone(ctx)
 	asserts.NoError(err)
@@ -287,11 +253,7 @@ func TestIsWorkNeeded(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
-	}
-
-	// need to init the handler so that the Helm release info is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{
-		CR: &v1alpha1.Module{},
+		CR:     &v1alpha1.Module{},
 		HelmInfo: handlerspi.HelmInfo{
 			HelmRelease: &handlerspi.HelmRelease{
 				Name:      releaseName,
@@ -299,8 +261,6 @@ func TestIsWorkNeeded(t *testing.T) {
 			},
 		},
 	}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	needed, result, err := handler.IsWorkNeeded(ctx)
 	asserts.NoError(err)
@@ -366,12 +326,8 @@ func TestWorkCompletedUpdateStatus(t *testing.T) {
 	ctx := handlerspi.HandlerContext{
 		Log:    vzlog.DefaultLogger(),
 		Client: cli,
+		CR:     module,
 	}
-
-	// need to init the handler so that the Module is set in the base handler
-	config := handlerspi.StateMachineHandlerConfig{CR: module}
-	_, err := handler.Init(ctx, config)
-	asserts.NoError(err)
 
 	result, err := handler.WorkCompletedUpdateStatus(ctx)
 	asserts.NoError(err)

--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -65,6 +65,7 @@ func (r Reconciler) reconcileAction(spictx controllerspi.ReconcileContext, cr *m
 	// Execute the state machine
 	sm := statemachine.StateMachine{
 		Handler: handler,
+		CR:      cr,
 	}
 	res := funcExecuteStateMachine(ctx, sm)
 	return res, nil

--- a/module-operator/controllers/module/reconciler_test.go
+++ b/module-operator/controllers/module/reconciler_test.go
@@ -307,10 +307,6 @@ func (h handler) GetWorkName() string {
 	return "install"
 }
 
-func (h handler) Init(context handlerspi.HandlerContext, config handlerspi.StateMachineHandlerConfig) (ctrl.Result, error) {
-	return ctrl.Result{}, nil
-}
-
 func (h handler) IsWorkNeeded(context handlerspi.HandlerContext) (bool, ctrl.Result, error) {
 	return true, ctrl.Result{}, nil
 }

--- a/module-operator/internal/handlerspi/handler_context.go
+++ b/module-operator/internal/handlerspi/handler_context.go
@@ -13,4 +13,6 @@ type HandlerContext struct {
 	ctrlclient.Client
 	Log    vzlog.VerrazzanoLogger
 	DryRun bool
+	CR     interface{}
+	HelmInfo
 }

--- a/module-operator/internal/handlerspi/statemachine_handler_spi.go
+++ b/module-operator/internal/handlerspi/statemachine_handler_spi.go
@@ -4,24 +4,13 @@
 package handlerspi
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
-
-// StateMachineHandlerConfig contains configuration data needed by the handlers
-type StateMachineHandlerConfig struct {
-	HelmInfo
-	CR     interface{}
-	Scheme *runtime.Scheme
-}
 
 // StateMachineHandler is the interface called by the state machine to do module related work
 type StateMachineHandler interface {
 	// GetWorkName returns the work name
 	GetWorkName() string
-
-	// Init initializes the component Helm information
-	Init(context HandlerContext, config StateMachineHandlerConfig) (ctrl.Result, error)
 
 	// IsWorkNeeded returns true if work is needed for the Module
 	IsWorkNeeded(context HandlerContext) (bool, ctrl.Result, error)

--- a/module-operator/internal/statemachine/statemachine.go
+++ b/module-operator/internal/statemachine/statemachine.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano-modules/module-operator/internal/handlerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/util"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -68,10 +67,8 @@ const (
 
 // StateMachine contains the fields needed to execute the state machine.
 type StateMachine struct {
-	*runtime.Scheme
-	CR       client.Object
-	HelmInfo *handlerspi.HelmInfo
-	Handler  handlerspi.StateMachineHandler
+	CR      client.Object
+	Handler handlerspi.StateMachineHandler
 }
 
 // Execute runs the state machine starting at the state stored in the tracker.
@@ -84,7 +81,6 @@ type StateMachine struct {
 // During state machine execution, a result may be returned to indicate that the
 // controller-runtime should requeue after a delay.  This is done when a handler is
 // waiting for a resource or some other condition.
-//
 func (s *StateMachine) Execute(handlerContext handlerspi.HandlerContext) ctrl.Result {
 	tracker := ensureTracker(s.CR, stateInit)
 
@@ -94,16 +90,6 @@ func (s *StateMachine) Execute(handlerContext handlerspi.HandlerContext) ctrl.Re
 	for tracker.state != stateEnd {
 		switch tracker.state {
 		case stateInit:
-			// Init the Handler
-			config := handlerspi.StateMachineHandlerConfig{
-				HelmInfo: *s.HelmInfo,
-				CR:       s.CR,
-				Scheme:   s.Scheme,
-			}
-			res, err := s.Handler.Init(handlerContext, config)
-			if res2 := util.DeriveResult(res, err); res2.Requeue {
-				return res2
-			}
 			tracker.state = stateCheckWorkNeeded
 
 		case stateCheckWorkNeeded:

--- a/module-operator/internal/statemachine/statemachine_test.go
+++ b/module-operator/internal/statemachine/statemachine_test.go
@@ -31,7 +31,6 @@ type handler struct {
 
 const (
 	getWorkName               = "GetWorkName"
-	initFunc                  = "init"
 	isWorkNeeded              = "isWorkNeeded"
 	preWorkUpdateStatus       = "preWorkUpdateStatus"
 	preWork                   = "preWork"
@@ -47,7 +46,6 @@ const (
 func getStatesInOrder() []string {
 	return []string{
 		getWorkName,
-		initFunc,
 		isWorkNeeded,
 		preWorkUpdateStatus,
 		preWork,
@@ -80,12 +78,10 @@ func TestAllStatesSucceed(t *testing.T) {
 		},
 	}
 	sm := StateMachine{
-		Scheme:   nil,
-		CR:       cr,
-		HelmInfo: &handlerspi.HelmInfo{},
-		Handler:  h,
+		CR:      cr,
+		Handler: h,
 	}
-	ctx := handlerspi.HandlerContext{Client: nil, Log: vzlog.DefaultLogger()}
+	ctx := handlerspi.HandlerContext{Client: nil, Log: vzlog.DefaultLogger(), HelmInfo: handlerspi.HelmInfo{}}
 
 	res := sm.Execute(ctx)
 	asserts.False(res.Requeue)
@@ -104,7 +100,7 @@ func TestAllStatesSucceed(t *testing.T) {
 // AND each subsequent state is not executed
 func TestEachStateRequeue(t *testing.T) {
 	asserts := assert.New(t)
-	ctx := handlerspi.HandlerContext{Client: nil, Log: vzlog.DefaultLogger()}
+	ctx := handlerspi.HandlerContext{Client: nil, Log: vzlog.DefaultLogger(), HelmInfo: handlerspi.HelmInfo{}}
 
 	// Check for a Requeue result for every state
 	for i, s := range getStatesInOrder() {
@@ -125,10 +121,8 @@ func TestEachStateRequeue(t *testing.T) {
 			},
 		}
 		sm := StateMachine{
-			Scheme:   nil,
-			CR:       cr,
-			HelmInfo: &handlerspi.HelmInfo{},
-			Handler:  h,
+			CR:      cr,
+			Handler: h,
 		}
 		b := h.behaviorMap[s]
 		b.Result = util.NewRequeueWithShortDelay()
@@ -159,7 +153,7 @@ func TestEachStateRequeue(t *testing.T) {
 // AND each subsequent state is not executed
 func TestNotDone(t *testing.T) {
 	asserts := assert.New(t)
-	ctx := handlerspi.HandlerContext{Client: nil, Log: vzlog.DefaultLogger()}
+	ctx := handlerspi.HandlerContext{Client: nil, Log: vzlog.DefaultLogger(), HelmInfo: handlerspi.HelmInfo{}}
 
 	tests := []struct {
 		name          string
@@ -192,10 +186,8 @@ func TestNotDone(t *testing.T) {
 				},
 			}
 			sm := StateMachine{
-				Scheme:   nil,
-				CR:       cr,
-				HelmInfo: &handlerspi.HelmInfo{},
-				Handler:  h,
+				CR:      cr,
+				Handler: h,
 			}
 			b := h.behaviorMap[test.stateNotDone]
 			b.boolResult = false
@@ -232,10 +224,6 @@ func (h handler) GetWorkName() string {
 	b := h.behaviorMap[getWorkName]
 	b.visited = true
 	return "install"
-}
-
-func (h handler) Init(context handlerspi.HandlerContext, config handlerspi.StateMachineHandlerConfig) (ctrl.Result, error) {
-	return h.procHandlerCall(initFunc)
 }
 
 func (h handler) IsWorkNeeded(context handlerspi.HandlerContext) (bool, ctrl.Result, error) {


### PR DESCRIPTION
Fix the handler API to be immutable, where the context parameter has CR specific information.
The old handler Init method saved context in the hander, which was shared across all CRs.
This fixes a problem that was exposed during concurrent testing.