### PR TITLE
e2e test improvements

### DIFF
--- a/tests/modules/helm/lifecycle/lifecycle_suite_test.go
+++ b/tests/modules/helm/lifecycle/lifecycle_suite_test.go
@@ -128,29 +128,34 @@ func (suite *HelmModuleLifecycleTestSuite) cleanup() {
 }
 
 func (suite *HelmModuleLifecycleTestSuite) createOrUpdateModule(logger testLogger, c *v1alpha1.PlatformV1alpha1Client, module *api.Module, overridesFile string, update bool) (*api.Module, *apiextensionsv1.JSON) {
-	var err error
-	op := "create"
-	if update {
-		op = "update"
-		module, err = c.Modules(module.GetNamespace()).Get(context.TODO(), module.GetName(), v1.GetOptions{})
-		suite.gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
+	var overrides *apiextensionsv1.JSON
 
-	logger.log("%s module %s, version %s, namespace %s", op, module.GetName(), module.Spec.Version, module.GetNamespace())
-	overrides := suite.generateOverridesFromFile(overridesFile)
-	module.Spec.Overrides = []api.Overrides{
-		{
-			Values: overrides,
-		},
-	}
+	suite.gomega.Eventually(func() error {
+		var err error
+		op := "create"
+		if update {
+			op = "update"
+			if module, err = c.Modules(module.GetNamespace()).Get(context.TODO(), module.GetName(), v1.GetOptions{}); err != nil {
+				return err
+			}
+		}
 
-	if update {
-		module, err = c.Modules(module.GetNamespace()).Update(context.TODO(), module, v1.UpdateOptions{})
-	} else {
-		module, err = c.Modules(module.GetNamespace()).Create(context.TODO(), module, v1.CreateOptions{})
-	}
+		logger.log("%s module %s, version %s, namespace %s", op, module.GetName(), module.Spec.Version, module.GetNamespace())
+		overrides = suite.generateOverridesFromFile(overridesFile)
+		module.Spec.Overrides = []api.Overrides{
+			{
+				Values: overrides,
+			},
+		}
 
-	suite.gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if update {
+			module, err = c.Modules(module.GetNamespace()).Update(context.TODO(), module, v1.UpdateOptions{})
+		} else {
+			module, err = c.Modules(module.GetNamespace()).Create(context.TODO(), module, v1.CreateOptions{})
+		}
+		return err
+	}, shortWaitTimeout, shortPollingInterval).ShouldNot(gomega.HaveOccurred())
+
 	return module, overrides
 }
 
@@ -229,15 +234,15 @@ func (suite *HelmModuleLifecycleTestSuite) deleteNamespace(ns string) bool {
 func (suite *HelmModuleLifecycleTestSuite) waitForModuleToBeReady(logger testLogger, c *v1alpha1.PlatformV1alpha1Client, module *api.Module) *api.Module {
 	var deployedModule *api.Module
 	var err error
-	suite.gomega.Eventually(func() bool {
+	suite.gomega.Eventually(func() (api.ModuleStateType, error) {
 		deployedModule, err = c.Modules(module.GetNamespace()).Get(context.TODO(), module.GetName(), v1.GetOptions{})
 		if err != nil {
 			logger.log("error while fetching module %s/%s, %v", module.GetNamespace(), module.GetName(), err.Error())
-			return false
+			return "", err
 		}
 
-		return deployedModule.Status.State == api.ModuleStateReady
-	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeTrue())
+		return deployedModule.Status.State, nil
+	}, shortWaitTimeout, shortPollingInterval).Should(gomega.BeEquivalentTo(api.ModuleStateReady))
 	return deployedModule
 }
 


### PR DESCRIPTION
The Module createOrUpdate operations were not being retried, and updates would occasionally fail with concurrent update "please retry on the latest version of the resource" errors, so I wrapped that in an `Eventually` so it will be retried on error.

I also improved another `Eventually` to not return bool which results in very little helpful information when the test fails. Now the test will report the specific error if one occurs, or the Module status if it does not match the expected status.