### PR TITLE
Fix workload readiness check

### DIFF
--- a/module-operator/controllers/module/handlers/common/workloads_ready.go
+++ b/module-operator/controllers/module/handlers/common/workloads_ready.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"context"
+
 	"github.com/verrazzano/verrazzano-modules/module-operator/internal/handlerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/k8s/readiness"
 	v1 "k8s.io/api/apps/v1"
@@ -12,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const helmKey = " meta.helm.sh/release-name"
+const helmKey = "meta.helm.sh/release-name"
 
 // CheckWorkLoadsReady checks to see if the workloads used by the Helm release are ready.
 func CheckWorkLoadsReady(ctx handlerspi.HandlerContext, releaseName string, namespace string) (bool, error) {

--- a/tests/modules/helm/lifecycle/lifecycle_suite_test.go
+++ b/tests/modules/helm/lifecycle/lifecycle_suite_test.go
@@ -129,25 +129,21 @@ func (suite *HelmModuleLifecycleTestSuite) cleanup() {
 
 func (suite *HelmModuleLifecycleTestSuite) createOrUpdateModule(logger testLogger, c *v1alpha1.PlatformV1alpha1Client, module *api.Module, overridesFile string, update bool) (*api.Module, *apiextensionsv1.JSON) {
 	var overrides *apiextensionsv1.JSON
+	op := "create"
+	if update {
+		op = "update"
+	}
+
+	logger.log("%s module %s, version %s, namespace %s", op, module.GetName(), module.Spec.Version, module.GetNamespace())
+	overrides = suite.generateOverridesFromFile(overridesFile)
+	module.Spec.Overrides = []api.Overrides{
+		{
+			Values: overrides,
+		},
+	}
 
 	suite.gomega.Eventually(func() error {
 		var err error
-		op := "create"
-		if update {
-			op = "update"
-			if module, err = c.Modules(module.GetNamespace()).Get(context.TODO(), module.GetName(), v1.GetOptions{}); err != nil {
-				return err
-			}
-		}
-
-		logger.log("%s module %s, version %s, namespace %s", op, module.GetName(), module.Spec.Version, module.GetNamespace())
-		overrides = suite.generateOverridesFromFile(overridesFile)
-		module.Spec.Overrides = []api.Overrides{
-			{
-				Values: overrides,
-			},
-		}
-
 		if update {
 			module, err = c.Modules(module.GetNamespace()).Update(context.TODO(), module, v1.UpdateOptions{})
 		} else {


### PR DESCRIPTION
We had a typo in the helm key we use to filter workloads, which was causing the readiness check to always return true.

Also fixed the e2e test to not fetch the existing Module CR on update, because it was overwriting the upgrade version and never really upgrading. This seems to resolve the issue where some of the Modules are stuck when running multiple installs/upgrades at the same time.