### PR TITLE
VZ-10059 change default metrics port 9110 

### DIFF
--- a/module-operator/manifests/charts/operators/verrazzano-module-operator/templates/deployment.yaml
+++ b/module-operator/manifests/charts/operators/verrazzano-module-operator/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           args:
             - --zap-log-level={{ .Values.logLevel }}
           ports:
-            - containerPort: 9100
+            - containerPort: {{ .Values.metricsPort }}
               name: http-metric
               protocol: TCP
           resources:

--- a/module-operator/manifests/charts/operators/verrazzano-module-operator/values.yaml
+++ b/module-operator/manifests/charts/operators/verrazzano-module-operator/values.yaml
@@ -15,6 +15,8 @@ nameOverride: ""
 fullnameOverride: ""
 logLevel: info
 
+metricsPort: 9110
+
 strategy:
   type: RollingUpdate
   rollingUpdate:


### PR DESCRIPTION
The module-operator was using the default port 9100 which conflicts with node-exporter since they both use the host network.  Change the default metrics port to 9110 and make it configurable.