### PR TITLE
VZ-10059 default to port 9110 for metrics (#154)

### DIFF
--- a/module-operator/manifests/charts/operators/verrazzano-module-operator/templates/deployment.yaml
+++ b/module-operator/manifests/charts/operators/verrazzano-module-operator/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           args:
             - --zap-log-level={{ .Values.logLevel }}
           ports:
-            - containerPort: 9100
+            - containerPort: {{ .Values.metricsPort }}
               name: http-metric
               protocol: TCP
           resources:

--- a/module-operator/manifests/charts/operators/verrazzano-module-operator/values.yaml
+++ b/module-operator/manifests/charts/operators/verrazzano-module-operator/values.yaml
@@ -15,6 +15,8 @@ nameOverride: ""
 fullnameOverride: ""
 logLevel: info
 
+metricsPort: 9110
+
 strategy:
   type: RollingUpdate
   rollingUpdate:


### PR DESCRIPTION
 Backport  module-operator to use port 9110 for metrics 