### PR TITLE
VZ-9808: Add e2e multi upgrade interrupt test

### DIFF
--- a/tests/modules/helm/interrupt/multi_upgrade_test.go
+++ b/tests/modules/helm/interrupt/multi_upgrade_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package interrupt
+
+import (
+	"fmt"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	api "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
+	"github.com/verrazzano/verrazzano-modules/tests/common"
+)
+
+func (suite *HelmModuleInterruptTestSuite) TestMultiUpgradeWhileReconciling() {
+	ctx := common.NewTestContext(suite.T())
+
+	module := &api.Module{}
+	err := common.UnmarshalTestFile(common.TEST_HELM_MODULE_FILE, module)
+	ctx.GomegaWithT.Expect(err).ShouldNot(HaveOccurred())
+
+	// GIVEN a Module resource
+	// WHEN the Module is created in the cluster
+	// THEN the Module Ready condition eventually is true and the installed Helm release has the expected values
+	module.Namespace = "default"
+	module.Spec.Version = "0.1.0"
+	module.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"deployment": {"delaySeconds": 1},"%s": "%s"}`, customKey, fredValue))}
+	suite.createModule(ctx, module)
+
+	version := suite.waitForModuleReadyCondition(ctx, module, corev1.ConditionTrue)
+	ctx.GomegaWithT.Expect(version).Should(Equal("0.1.0"))
+	suite.verifyHelmValues(ctx, module.Name, module.Namespace, fredValue)
+
+	// GIVEN a Module resource version is being upgraded
+	// WHEN the Module is updated while it's upgrading and then immediately upgraded again and then updated again
+	// THEN the Module Ready condition eventually is true and the installed Helm release has the expected values
+
+	// Note that we modify the delaySeconds so that the deployment gets updated and pods are rolled out
+	module.Spec.Version = "0.1.1"
+	module.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"deployment": {"delaySeconds": 5},"%s": "%s"}`, customKey, fredValue))}
+	ctx.T.Logf("Upgrading module to version %s", module.Spec.Version)
+	suite.updateModule(ctx, module)
+
+	// Wait for reconciling to begin
+	suite.waitForModuleReadyCondition(ctx, module, corev1.ConditionFalse)
+
+	// Update the values
+	module.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"deployment": {"delaySeconds": 6},"%s": "%s"}`, customKey, barneyValue))}
+	suite.updateModule(ctx, module)
+
+	// Upgrade the Module again
+	module.Spec.Version = "0.1.2"
+	module.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"deployment": {"delaySeconds": 7},"%s": "%s"}`, customKey, barneyValue))}
+	ctx.T.Logf("Upgrading module to version %s", module.Spec.Version)
+	suite.updateModule(ctx, module)
+
+	// Update the values again
+	module.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"deployment": {"delaySeconds": 5},"%s": "%s"}`, customKey, dinoValue))}
+	suite.updateModule(ctx, module)
+
+	version = suite.waitForModuleReadyCondition(ctx, module, corev1.ConditionTrue)
+	ctx.GomegaWithT.Expect(version).Should(Equal("0.1.2"))
+	suite.verifyHelmValues(ctx, module.Name, module.Namespace, dinoValue)
+
+	// GIVEN a Module resource
+	// WHEN the Module is deleted
+	// THEN the Module is removed from the cluster and the Helm release is uninstalled
+	suite.deleteModule(ctx, module)
+	suite.verifyModuleAndHelmReleaseDeleted(ctx, module)
+}

--- a/tests/modules/helm/interrupt/update_test.go
+++ b/tests/modules/helm/interrupt/update_test.go
@@ -23,9 +23,10 @@ const (
 	shortWaitTimeout     = 3 * time.Minute
 	shortPollingInterval = 2 * time.Second
 
-	customKey = "customKey"
-	fredValue = "fred"
-	dinoValue = "dino"
+	customKey   = "customKey"
+	fredValue   = "fred"
+	barneyValue = "barney"
+	dinoValue   = "dino"
 )
 
 // TestUpdateWhileReconciling tests updating a Module while it's reconciling and validates that all updates
@@ -56,7 +57,7 @@ func (suite *HelmModuleInterruptTestSuite) TestUpdateWhileReconciling() {
 	// GIVEN a Module resource is updated and the Ready condition is false
 	// WHEN the Module values are updated again
 	// THEN the Module Ready condition eventually is true and the installed Helm release has the expected values
-	module.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"deployment": {"delaySeconds": 8},"%s": "barney"}`, customKey))}
+	module.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`{"deployment": {"delaySeconds": 8},"%s": "%s"}`, customKey, barneyValue))}
 	suite.updateModule(ctx, module)
 
 	suite.waitForModuleReadyCondition(ctx, module, corev1.ConditionFalse)


### PR DESCRIPTION
This end-to-end test upgrades the Module multiple times and also updates the values, all while reconciling.

Sample output:
```
=== RUN   TestHelmModuleInterruptTestSuite/TestMultiUpgradeWhileReconciling
    update_test.go:80: Installing module default/vz-test-module
    update_test.go:117: Waiting for module ready condition to be: True
    update_test.go:136: Verifying helm release values
    multi_upgrade_test.go:42: Upgrading module to version 0.1.1
    update_test.go:88: Updating module values
    update_test.go:117: Waiting for module ready condition to be: False
    update_test.go:88: Updating module values
    multi_upgrade_test.go:55: Upgrading module to version 0.1.2
    update_test.go:88: Updating module values
    update_test.go:88: Updating module values
    update_test.go:117: Waiting for module ready condition to be: True
    update_test.go:136: Verifying helm release values
    update_test.go:143: Deleting module default/vz-test-module
    update_test.go:157: Waiting for module to be deleted
--- PASS: TestHelmModuleInterruptTestSuite (50.54s)
    --- PASS: TestHelmModuleInterruptTestSuite/TestMultiUpgradeWhileReconciling (50.54s)
PASS
ok  	github.com/verrazzano/verrazzano-modules/tests/modules/helm/interrupt	51.205s
```
