### PR TITLE
VZ-10084: Add support for multi architecture images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -313,7 +313,7 @@ def buildImages(dockerImageTag) {
         cd ${GO_REPO_PATH}/${GIT_REPO_DIR}
 
         # Release and main branches build multi architecture images, branch builds are amd unless the multi arch box is checked
-        if [[ ${params.BUILD_MULTI_ARCH_IMAGES} || ${env.BRANCH_NAME} == "main" || ${env.BRANCH_NAME} == "release*" ]]
+        if [[ ${params.BUILD_MULTI_ARCH_IMAGES} == true || ${env.BRANCH_NAME} == "main" || ${env.BRANCH_NAME} == "release*" ]]
         then
             echo 'Building multi architecture container images...'
             make docker-build-multi-arch \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
 
     parameters {
         booleanParam (description: 'Whether to perform a scan of the built images', name: 'PERFORM_SCAN', defaultValue: false)
+        booleanParam (description: 'Whether to build multi architecture images. Always true for main and release branch builds. Defaults to false for branch builds.', name: 'BUILD_MULTI_ARCH_IMAGES', defaultValue: false)
     }
 
     environment {
@@ -306,16 +307,29 @@ def checkRepoClean() {
 }
 
 // Called in Stage Build steps
-// Makes target docker push for application/platform operator and analysis
+// Builds and pushes the module-operator images
 def buildImages(dockerImageTag) {
     sh """
         cd ${GO_REPO_PATH}/${GIT_REPO_DIR}
-        echo 'Building container images...'
-        make docker-push \
-            DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} \
-            DOCKER_IMAGE_TAG=${dockerImageTag} \
-            VERRAZZANO_MODULE_OPERATOR_IMAGE_NAME=${DOCKER_MODULE_IMAGE_NAME}
-            CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
+
+        # Release and main branches build multi architecture images, branch builds are amd unless the multi arch box is checked
+        if [[ ${params.BUILD_MULTI_ARCH_IMAGES} || ${env.BRANCH_NAME} == "main" || ${env.BRANCH_NAME} == "release*" ]]
+        then
+            echo 'Building multi architecture container images...'
+            make docker-build-multi-arch \
+                DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} \
+                DOCKER_IMAGE_TAG=${dockerImageTag} \
+                VERRAZZANO_MODULE_OPERATOR_IMAGE_NAME=${DOCKER_MODULE_IMAGE_NAME}
+                CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
+        else
+            echo 'Building container images...'
+            make docker-push \
+                DOCKER_REPO=${env.DOCKER_REPO} DOCKER_NAMESPACE=${env.DOCKER_NAMESPACE} \
+                DOCKER_IMAGE_TAG=${dockerImageTag} \
+                VERRAZZANO_MODULE_OPERATOR_IMAGE_NAME=${DOCKER_MODULE_IMAGE_NAME}
+                CREATE_LATEST_TAG=${CREATE_LATEST_TAG}
+        fi
+
         #${GO_REPO_PATH}/${GIT_REPO_DIR}/tools/scripts/generate_image_list.sh $WORKSPACE/generated-verrazzano-bom.json $WORKSPACE/verrazzano_images.txt
     """
 }

--- a/Makefile
+++ b/Makefile
@@ -51,19 +51,23 @@ clean: ## remove coverage and test results
 #@ Build
 
 .PHONY: docker-build
-docker-build: ## build and push all images
+docker-build: ## build all images
 	(cd module-operator; make docker-build DOCKER_IMAGE_NAME=${VERRAZZANO_MODULE_OPERATOR_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG})
+
+.PHONY: docker-build-multi-arch
+docker-build-multi-arch: ## build and push multi architecture images
+	(cd module-operator; make docker-build-multi-arch DOCKER_IMAGE_NAME=${VERRAZZANO_MODULE_OPERATOR_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG})
 
 .PHONY: docker-push
 docker-push: ## build and push all images
 	(cd module-operator; make docker-push DOCKER_IMAGE_NAME=${VERRAZZANO_MODULE_OPERATOR_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG})
 
 .PHONY: docker-push-debug
-docker-push-debug: ## build and push all images
+docker-push-debug: ## build and push debug images
 	(cd module-operator; make docker-push-debug DOCKER_IMAGE_NAME=${VERRAZZANO_MODULE_OPERATOR_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG})
 
 .PHONY: generate-operator-artifacts
-generate-operator-artifacts: ## build and push all images
+generate-operator-artifacts: ## generates Helm template manifest
 	(cd module-operator; make generate-operator-artifacts DOCKER_IMAGE_NAME=${VERRAZZANO_MODULE_OPERATOR_IMAGE_NAME} DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG})
 
 #@ Testing

--- a/make/build.mk
+++ b/make/build.mk
@@ -69,14 +69,18 @@ docker-build-common:
 	@echo Building ${NAME} image ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 	# the TPL file needs to be copied into this dir so it is in the ${DOCKER_CMD} build context
 	#cp ../THIRD_PARTY_LICENSES.txt .
-	${DOCKER_CMD} version
+ifdef DOCKER_CREDS_USR
+ifdef DOCKER_CREDS_PSW
+	@${DOCKER_CMD} login ${DOCKER_REPO} --username ${DOCKER_CREDS_USR} --password ${DOCKER_CREDS_PSW}
+endif
+endif
 	${DOCKER_CMD} buildx create --use
-	${DOCKER_CMD} buildx build --pull --platform linux/arm64,linux/amd64 -f Dockerfile \
+	${DOCKER_CMD} buildx build --push --platform linux/arm64,linux/amd64 -f Dockerfile \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
-		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ..
+		-t ${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG} ..
 
 .PHONY: docker-push
-docker-push: docker-build docker-push-common
+docker-push: docker-build
 
 .PHONY: docker-push-debug
 docker-push-debug: docker-build-debug docker-push-common

--- a/make/build.mk
+++ b/make/build.mk
@@ -69,7 +69,7 @@ docker-build-common:
 	@echo Building ${NAME} image ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 	# the TPL file needs to be copied into this dir so it is in the ${DOCKER_CMD} build context
 	#cp ../THIRD_PARTY_LICENSES.txt .
-	${DOCKER_CMD} build --pull -f Dockerfile \
+	${DOCKER_CMD} buildx build --pull --platform linux/arm64,linux/amd64 -f Dockerfile \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ..
 

--- a/make/build.mk
+++ b/make/build.mk
@@ -1,7 +1,7 @@
 # Copyright (C) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-export DOCKER_CMD ?= docker
+export DOCKER_CMD ?= DOCKER_CLI_EXPERIMENTAL=enabled docker
 ##@ Development
 
 .PHONY: fmt
@@ -70,7 +70,7 @@ docker-build-common:
 	# the TPL file needs to be copied into this dir so it is in the ${DOCKER_CMD} build context
 	#cp ../THIRD_PARTY_LICENSES.txt .
 	${DOCKER_CMD} version
-	${DOCKER_CMD} buildx build --platform linux/arm64,linux/amd64 -f Dockerfile \
+	${DOCKER_CMD} buildx build --pull --platform linux/arm64,linux/amd64 -f Dockerfile \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ..
 

--- a/make/build.mk
+++ b/make/build.mk
@@ -69,6 +69,7 @@ docker-build-common:
 	@echo Building ${NAME} image ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 	# the TPL file needs to be copied into this dir so it is in the ${DOCKER_CMD} build context
 	#cp ../THIRD_PARTY_LICENSES.txt .
+	${DOCKER_CMD} docker version
 	${DOCKER_CMD} buildx build --platform linux/arm64,linux/amd64 -f Dockerfile \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ..

--- a/make/build.mk
+++ b/make/build.mk
@@ -70,6 +70,7 @@ docker-build-common:
 	# the TPL file needs to be copied into this dir so it is in the ${DOCKER_CMD} build context
 	#cp ../THIRD_PARTY_LICENSES.txt .
 	${DOCKER_CMD} version
+	${DOCKER_CMD} buildx create --use
 	${DOCKER_CMD} buildx build --pull --platform linux/arm64,linux/amd64 -f Dockerfile \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ..

--- a/make/build.mk
+++ b/make/build.mk
@@ -69,7 +69,7 @@ docker-build-common:
 	@echo Building ${NAME} image ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 	# the TPL file needs to be copied into this dir so it is in the ${DOCKER_CMD} build context
 	#cp ../THIRD_PARTY_LICENSES.txt .
-	${DOCKER_CMD} buildx build --pull --platform linux/arm64,linux/amd64 -f Dockerfile \
+	${DOCKER_CMD} buildx build --platform linux/arm64,linux/amd64 -f Dockerfile \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ..
 

--- a/make/build.mk
+++ b/make/build.mk
@@ -69,7 +69,7 @@ docker-build-common:
 	@echo Building ${NAME} image ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 	# the TPL file needs to be copied into this dir so it is in the ${DOCKER_CMD} build context
 	#cp ../THIRD_PARTY_LICENSES.txt .
-	${DOCKER_CMD} docker version
+	${DOCKER_CMD} version
 	${DOCKER_CMD} buildx build --platform linux/arm64,linux/amd64 -f Dockerfile \
 		--build-arg BASE_IMAGE=${BASE_IMAGE} \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ..

--- a/module-operator/Dockerfile
+++ b/module-operator/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o /usr/local/bin/verrazzano-module-operator ./module-operator/main
 RUN chmod 500 /usr/local/bin/verrazzano-module-operator
 
 # Create the verrazzano-module-operator image
-FROM ghcr.io/oracle/oraclelinux:8-slim AS final
+FROM $BASE_IMAGE AS final
 
 RUN microdnf update -y && \
     microdnf clean all && \

--- a/module-operator/Dockerfile
+++ b/module-operator/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o /usr/local/bin/verrazzano-module-operator ./module-operator/main
 RUN chmod 500 /usr/local/bin/verrazzano-module-operator
 
 # Create the verrazzano-module-operator image
-FROM $BASE_IMAGE AS final
+FROM ghcr.io/oracle/oraclelinux:8-slim AS final
 
 RUN microdnf update -y && \
     microdnf clean all && \


### PR DESCRIPTION
This PR adds support for multi architecture images that will run on both amd64 and arm64. CI branch builds by default will build single architecture amd images because multi arch builds take an order of magnitude longer to build. There is a build parameter to override this behavior. Release and main branch builds will always build multi architecture images.

I tested the following:
1. Build locally using the same make targets that we have been using, all works and produces a single architecture amd image
2. Branch build in CI with default settings, produces a single architecture amd image
3. Branch build in CI with multi arch checkbox checked, produces a multi architecture image
4. Installed the multi arch image in a kind cluster running on an M1 Mac, deployed a test Module
