### PR TITLE
VZ-10309 VPO integration

### DIFF
--- a/module-operator/apis/platform/v1alpha1/module_types.go
+++ b/module-operator/apis/platform/v1alpha1/module_types.go
@@ -15,6 +15,7 @@ import (
 // +kubebuilder:resource:path=modules,shortName=module;modules
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.lastSuccessfulVersion",description="The current version of the Verrazzano platform."
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[:].status",description="True if the Module is ready"
+// +kubebuilder:printcolumn:name="Message",type="string",priority=2,JSONPath=".status.conditions[:].message",description="Lifecycle message"
 // +genclient
 
 // Module specifies a Verrazzano Module instance.

--- a/module-operator/apis/platform/v1alpha1/module_types.go
+++ b/module-operator/apis/platform/v1alpha1/module_types.go
@@ -15,6 +15,7 @@ import (
 // +kubebuilder:resource:path=modules,shortName=module;modules
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.lastSuccessfulVersion",description="The current version of the Verrazzano platform."
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[:].status",description="True if the Module is ready"
+// +kubebuilder:printcolumn:name="Transition Time",type="string",priority=2,JSONPath=".status.conditions[:].lastTransitionTime",description="Last transition time"
 // +kubebuilder:printcolumn:name="Message",type="string",priority=2,JSONPath=".status.conditions[:].message",description="Lifecycle message"
 // +genclient
 

--- a/module-operator/controllers/module/finalizer.go
+++ b/module-operator/controllers/module/finalizer.go
@@ -26,7 +26,7 @@ func (r Reconciler) PreRemoveFinalizer(spictx controllerspi.ReconcileContext, u 
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, cr); err != nil {
 		return result.NewResult()
 	}
-	return r.reconcileAction(spictx, cr, r.HandlerInfo.DeleteActionHandler)
+	return r.reconcileAction(spictx, cr, r.ModuleHandlerInfo.DeleteActionHandler)
 }
 
 // PostRemoveFinalizer is called after the finalizer is successfully removed.

--- a/module-operator/controllers/module/finalizer_test.go
+++ b/module-operator/controllers/module/finalizer_test.go
@@ -106,7 +106,7 @@ func TestPreRemoveFinalizer(t *testing.T) {
 			r := Reconciler{
 				Client:      clientBuilder.Build(),
 				Scheme:      initScheme(),
-				HandlerInfo: test.moduleInfo,
+				ModuleControllerConfig: ModuleControllerConfig{ModuleHandlerInfo: test.moduleInfo},
 			}
 			uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
 			asserts.NoError(err)

--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -96,7 +96,7 @@ func (r Reconciler) reconcileAction(spictx controllerspi.ReconcileContext, cr *m
 // getActionHandler must return one of the Module action handlers.
 func (r *Reconciler) getActionHandler(ctx handlerspi.HandlerContext, cr *moduleapi.Module) (handlerspi.StateMachineHandler, result.Result) {
 	if !status.IsInstalled(cr) {
-		return r.HandlerInfo.InstallActionHandler, result.NewResult()
+		return r.ModuleHandlerInfo.InstallActionHandler, result.NewResult()
 	}
 
 	// return UpgradeAction only when the desired version is different from current
@@ -106,9 +106,9 @@ func (r *Reconciler) getActionHandler(ctx handlerspi.HandlerContext, cr *modulea
 		return nil, result.NewResultShortRequeueDelay()
 	}
 	if upgradeNeeded {
-		return r.HandlerInfo.UpgradeActionHandler, result.NewResult()
+		return r.ModuleHandlerInfo.UpgradeActionHandler, result.NewResult()
 	}
-	return r.HandlerInfo.UpdateActionHandler, result.NewResult()
+	return r.ModuleHandlerInfo.UpdateActionHandler, result.NewResult()
 
 }
 

--- a/module-operator/controllers/module/reconciler_test.go
+++ b/module-operator/controllers/module/reconciler_test.go
@@ -159,9 +159,9 @@ func TestReconcileSuccess(t *testing.T) {
 			scheme := initScheme()
 			clientBuilder := fakes.NewClientBuilder().WithScheme(scheme)
 			r := Reconciler{
-				Client:      clientBuilder.Build(),
-				Scheme:      initScheme(),
-				HandlerInfo: test.moduleInfo,
+				Client:                 clientBuilder.Build(),
+				Scheme:                 initScheme(),
+				ModuleControllerConfig: ModuleControllerConfig{ModuleHandlerInfo: test.moduleInfo},
 			}
 			uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
 			asserts.NoError(err)
@@ -303,9 +303,9 @@ func TestReconcileErrors(t *testing.T) {
 			scheme := initScheme()
 			clientBuilder := fakes.NewClientBuilder().WithScheme(scheme)
 			r := Reconciler{
-				Client:      clientBuilder.Build(),
-				Scheme:      initScheme(),
-				HandlerInfo: test.moduleInfo,
+				Client:                 clientBuilder.Build(),
+				Scheme:                 initScheme(),
+				ModuleControllerConfig: ModuleControllerConfig{ModuleHandlerInfo: test.moduleInfo},
 			}
 			uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
 			asserts.NoError(err)

--- a/module-operator/controllers/module/status/status.go
+++ b/module-operator/controllers/module/status/status.go
@@ -49,10 +49,7 @@ func UpdateReadyConditionReconciling(ctx handlerspi.HandlerContext, module *modu
 }
 
 // UpdateReadyConditionFailed updates the Ready condition when the module has failed
-func UpdateReadyConditionFailed(ctx handlerspi.HandlerContext, module *moduleapi.Module, reason moduleapi.ModuleConditionReason, msgDetail string) result.Result {
-	msgTemplate := readyConditionMessages[reason]
-	msg := fmt.Sprintf(msgTemplate, module.Name, module.Spec.TargetNamespace, ctx.HelmRelease.Name, msgDetail)
-
+func UpdateReadyConditionFailed(ctx handlerspi.HandlerContext, module *moduleapi.Module, reason moduleapi.ModuleConditionReason, msg string) result.Result {
 	return updateReadyCondition(ctx, module, reason, corev1.ConditionFalse, msg)
 }
 

--- a/module-operator/main.go
+++ b/module-operator/main.go
@@ -37,20 +37,32 @@ func main() {
 	}
 
 	// init Helm controller
-	if err := module.InitController(mgr, helmfactory.NewModuleHandlerInfo(), moduleapi.HelmModuleClass); err != nil {
+	if err := module.InitController(module.ModuleControllerConfig{
+		ControllerManager: mgr,
+		ModuleHandlerInfo: helmfactory.NewModuleHandlerInfo(),
+		ModuleClass:       moduleapi.HelmModuleClass,
+	}); err != nil {
 		log.Errorf("Failed to start Helm controller", err)
 		return
 	}
 
 	// init Calico controller
-	if err := module.InitController(mgr, calicofactory.NewModuleHandlerInfo(), moduleapi.CalicoModuleClass); err != nil {
-		log.Errorf("Failed to start the Calico controller", err)
+	if err := module.InitController(module.ModuleControllerConfig{
+		ControllerManager: mgr,
+		ModuleHandlerInfo: calicofactory.NewModuleHandlerInfo(),
+		ModuleClass:       moduleapi.CalicoModuleClass,
+	}); err != nil {
+		log.Errorf("Failed to start Calico controller", err)
 		return
 	}
 
 	// init CCM controller
-	if err := module.InitController(mgr, ccmfactory.NewModuleHandlerInfo(), moduleapi.CCMModuleClass); err != nil {
-		log.Errorf("Failed to start OCI-CCM controller", err)
+	if err := module.InitController(module.ModuleControllerConfig{
+		ControllerManager: mgr,
+		ModuleHandlerInfo: ccmfactory.NewModuleHandlerInfo(),
+		ModuleClass:       moduleapi.CCMModuleClass,
+	}); err != nil {
+		log.Errorf("Failed to start OCI-CCM  controller", err)
 		return
 	}
 

--- a/module-operator/manifests/charts/operators/verrazzano-module-operator/crds/platform.verrazzano.io_modules.yaml
+++ b/module-operator/manifests/charts/operators/verrazzano-module-operator/crds/platform.verrazzano.io_modules.yaml
@@ -29,10 +29,15 @@ spec:
       jsonPath: .status.conditions[:].status
       name: Ready
       type: string
+    - description: Lifecycle message
+      jsonPath: .status.conditions[:].message
+      name: Message
+      priority: 2
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Module specifies a Verrazzano Module instance
+        description: Module specifies a Verrazzano Module instance.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -47,28 +52,30 @@ spec:
           metadata:
             type: object
           spec:
-            description: ModuleSpec defines the attributes for a Verrazzano Module
-              instance
+            description: ModuleSpec defines the specification for a Verrazzano Module
+              instance.
             properties:
               moduleName:
-                description: Module name is the well-known Module name
+                description: Module name is the well-known Module name.
                 type: string
               targetNamespace:
                 description: TargetNamespace is the namespace where the Module will
-                  be installed
+                  be installed.
                 type: string
               values:
-                description: Values specifies overrides using inline YAML.  Values
-                  have precedence over ValuesFrom
+                description: Values specifies configuration values using inline YAML.
+                  Values have precedence over ValuesFrom.
                 x-kubernetes-preserve-unknown-fields: true
               valuesFrom:
-                description: ValuesFrom specifies the values from a Configmap or Secret
+                description: ValuesFrom specifies the values from a Configmap or Secret.
+                  Each entry in the list has precedence over all previous entries
+                  in the list.
                 items:
-                  description: ValuesFromSource identifies value overrides for a Module.
+                  description: ValuesFromSource specifies value overrides for a Module.
                   properties:
                     configMapRef:
                       description: ConfigMapRef is a selector for a ConfigMap containing
-                        override data.
+                        values data.
                       properties:
                         key:
                           description: The key to select.
@@ -87,7 +94,7 @@ spec:
                       x-kubernetes-map-type: atomic
                     secretRef:
                       description: SecretRef is a selector for a Secret containing
-                        override data.
+                        values data.
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -108,14 +115,14 @@ spec:
                   type: object
                 type: array
               version:
-                description: Version is the desired version of the Module
+                description: Version is the desired version of the Module.
                 type: string
             type: object
           status:
             description: ModuleStatus defines the action state of the Module resource.
             properties:
               conditions:
-                description: Conditions are the list of conditions for the module.
+                description: Conditions are the list of conditions for the Module.
                 items:
                   description: ModuleCondition describes the current condition of
                     the Module.
@@ -130,7 +137,7 @@ spec:
                       type: string
                     reason:
                       description: Reason for the condition.  This is a machine-readable
-                        one word value
+                        one word value.
                       type: string
                     status:
                       description: 'Status of the condition: one of `True`, `False`,
@@ -148,11 +155,11 @@ spec:
                 type: array
               lastSuccessfulGeneration:
                 description: LastSuccessfulGeneration is the last generation of the
-                  module that was successfully reconciled.
+                  Module that was successfully reconciled.
                 format: int64
                 type: integer
               lastSuccessfulVersion:
-                description: LastSuccessfulVersion is the last version of the module
+                description: LastSuccessfulVersion is the last version of the Module
                   that was successfully reconciled.
                 type: string
             type: object

--- a/module-operator/manifests/charts/operators/verrazzano-module-operator/crds/platform.verrazzano.io_modules.yaml
+++ b/module-operator/manifests/charts/operators/verrazzano-module-operator/crds/platform.verrazzano.io_modules.yaml
@@ -29,6 +29,11 @@ spec:
       jsonPath: .status.conditions[:].status
       name: Ready
       type: string
+    - description: Last transition time
+      jsonPath: .status.conditions[:].lastTransitionTime
+      name: Transition Time
+      priority: 2
+      type: string
     - description: Lifecycle message
       jsonPath: .status.conditions[:].message
       name: Message

--- a/pkg/controller/base/controllerspi/controllerspi.go
+++ b/pkg/controller/base/controllerspi/controllerspi.go
@@ -62,7 +62,7 @@ type EventFilter interface {
 
 // Watcher is an interface used by controllers that watch resources
 type Watcher interface {
-	// GetWatchDescriptors returns the list of object kinds being watched
+	// GetWatchDescriptors returns the list of WatchDescriptor for objects being watched
 	GetWatchDescriptors() []WatchDescriptor
 }
 

--- a/pkg/helm/overrides.go
+++ b/pkg/helm/overrides.go
@@ -34,7 +34,7 @@ func LoadOverrideFiles(log vzlog.VerrazzanoLogger, client ctrlclient.Client, rel
 	var err error
 
 	// Getting user defined Helm overrides as the highest priority
-	overrideStrings, err := getInstallOverridesYAML(log, client, moduleOverrides, mlcNamespace)
+	overrideStrings, err := GetInstallOverridesYAML(log, client, moduleOverrides, mlcNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helm/overrides_yaml.go
+++ b/pkg/helm/overrides_yaml.go
@@ -15,15 +15,15 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// getInstallOverridesYAML takes the list of ValuesFrom and returns a string array of YAMLs
-func getInstallOverridesYAML(log vzlog.VerrazzanoLogger, client client.Client, overrides []ValueOverrides,
+// GetInstallOverridesYAML takes the list of ValuesFrom and returns a string array of YAMLs
+func GetInstallOverridesYAML(log vzlog.VerrazzanoLogger, client client.Client, overrides []ValueOverrides,
 	mlcNamespace string) ([]string, error) {
 	var overrideStrings []string
 	for _, override := range overrides {
 		// Check if ConfigMapRef is populated and gather data
 		if override.ConfigMapRef != nil {
 			// Get the ConfigMap data
-			data, err := getConfigMapOverrides(log, client, override.ConfigMapRef, mlcNamespace)
+			data, err := GetConfigMapOverrides(log, client, override.ConfigMapRef, mlcNamespace)
 			if err != nil {
 				return overrideStrings, err
 			}
@@ -33,7 +33,7 @@ func getInstallOverridesYAML(log vzlog.VerrazzanoLogger, client client.Client, o
 		// Check if SecretRef is populated and gather data
 		if override.SecretRef != nil {
 			// Get the Secret data
-			data, err := getSecretOverrides(log, client, override.SecretRef, mlcNamespace)
+			data, err := GetSecretOverrides(log, client, override.SecretRef, mlcNamespace)
 			if err != nil {
 				return overrideStrings, err
 			}
@@ -52,8 +52,8 @@ func getInstallOverridesYAML(log vzlog.VerrazzanoLogger, client client.Client, o
 	return overrideStrings, nil
 }
 
-// getConfigMapOverrides takes a ConfigMap selector and returns the YAML data and handles k8s api errors appropriately
-func getConfigMapOverrides(log vzlog.VerrazzanoLogger, client client.Client, selector *v1.ConfigMapKeySelector,
+// GetConfigMapOverrides takes a ConfigMap selector and returns the YAML data and handles k8s api errors appropriately
+func GetConfigMapOverrides(log vzlog.VerrazzanoLogger, client client.Client, selector *v1.ConfigMapKeySelector,
 	namespace string) (string, error) {
 	configMap := &v1.ConfigMap{}
 	nsn := types.NamespacedName{Name: selector.Name, Namespace: namespace}
@@ -84,8 +84,8 @@ func getConfigMapOverrides(log vzlog.VerrazzanoLogger, client client.Client, sel
 	return fieldData, nil
 }
 
-// getSecretOverrides takes a Secret selector and returns the YAML data and handles k8s api errors appropriately
-func getSecretOverrides(log vzlog.VerrazzanoLogger, client client.Client, selector *v1.SecretKeySelector,
+// GetSecretOverrides takes a Secret selector and returns the YAML data and handles k8s api errors appropriately
+func GetSecretOverrides(log vzlog.VerrazzanoLogger, client client.Client, selector *v1.SecretKeySelector,
 	namespace string) (string, error) {
 	sec := &v1.Secret{}
 	nsn := types.NamespacedName{Name: selector.Name, Namespace: namespace}


### PR DESCRIPTION
A few changes needed to integrate VPO with modules.
Add ability to specify watch descriptors when creating a controller
Cleanup status updating so it doesn't write condition if no information changed
Add kubebuilder annotations so that kubectl -o wide displays more columns
Make some functions/methods public so that they can be used by VPO