### PR TITLE
VZ-10451 refactor watches and watch configmap and secret

### DIFF
--- a/module-operator/controllers/module/finalizer_test.go
+++ b/module-operator/controllers/module/finalizer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	moduleapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
 	"github.com/verrazzano/verrazzano-modules/module-operator/internal/statemachine"
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/basecontroller"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/handlerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
@@ -104,8 +105,10 @@ func TestPreRemoveFinalizer(t *testing.T) {
 			scheme := initScheme()
 			clientBuilder := fakes.NewClientBuilder().WithScheme(scheme)
 			r := Reconciler{
-				Client:      clientBuilder.Build(),
-				Scheme:      initScheme(),
+				BaseReconciler: &basecontroller.BaseReconciler {
+					Client:     clientBuilder.Build(),
+					Scheme:     initScheme(),
+				},
 				ModuleControllerConfig: ModuleControllerConfig{ModuleHandlerInfo: test.moduleInfo},
 			}
 			uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
@@ -145,8 +148,10 @@ func TestPostRemoveFinalizer(t *testing.T) {
 	scheme := initScheme()
 	clientBuilder := fakes.NewClientBuilder().WithScheme(scheme)
 	r := Reconciler{
-		Client: clientBuilder.Build(),
-		Scheme: initScheme(),
+		BaseReconciler: &basecontroller.BaseReconciler {
+			Client:     clientBuilder.Build(),
+			Scheme:     initScheme(),
+		},
 	}
 
 	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)

--- a/module-operator/controllers/module/handlers/helm/install/install_handler_test.go
+++ b/module-operator/controllers/module/handlers/helm/install/install_handler_test.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
@@ -132,7 +131,7 @@ func TestPreWork(t *testing.T) {
 
 	res := handler.PreWork(ctx)
 	asserts.NoError(res.GetError())
-	asserts.Equal(ctrl.Result{Requeue: true, RequeueAfter: 1000000000}, res.GetCtrlRuntimeResult())
+	asserts.True(res.GetCtrlRuntimeResult().Requeue)
 
 	// fetch the Module and validate that the spec version has been set
 	err := cli.Get(context.TODO(), types.NamespacedName{Name: moduleName, Namespace: namespace}, module)

--- a/module-operator/controllers/module/manager.go
+++ b/module-operator/controllers/module/manager.go
@@ -9,7 +9,6 @@ import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/basecontroller"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/handlerspi"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -18,8 +17,7 @@ import (
 var _ controllerspi.Reconciler = Reconciler{}
 
 type Reconciler struct {
-	Client client.Client
-	Scheme *runtime.Scheme
+	*basecontroller.BaseReconciler
 	ModuleControllerConfig
 }
 
@@ -34,7 +32,7 @@ type ModuleControllerConfig struct {
 func InitController(modConfig ModuleControllerConfig) error {
 	controller := Reconciler{}
 
-	// The config MUST contain at least the Reconciler.  Other spi interfaces are optional.
+	// The config MUST contain at least the BaseReconciler.  Other spi interfaces are optional.
 	config := basecontroller.ControllerConfig{
 		Reconciler:  &controller,
 		Finalizer:   &controller,
@@ -42,14 +40,13 @@ func InitController(modConfig ModuleControllerConfig) error {
 		Watcher:     &controller,
 	}
 
-	baseController, err := basecontroller.CreateControllerAndAddItToManager(modConfig.ControllerManager, config)
+	baseReconciler, err := basecontroller.CreateControllerAndAddItToManager(modConfig.ControllerManager, config)
 	if err != nil {
 		return err
 	}
+	controller.BaseReconciler = baseReconciler
 
 	// init other controller fields
-	controller.Client = baseController.Client
-	controller.Scheme = baseController.Scheme
 	controller.ModuleControllerConfig = modConfig
 	return nil
 }

--- a/module-operator/controllers/module/manager.go
+++ b/module-operator/controllers/module/manager.go
@@ -65,6 +65,7 @@ func (r Reconciler) HandlePredicateEvent(cli client.Client, object client.Object
 	return mlc.Spec.ModuleName == string(r.ModuleClass)
 }
 
+// GetWatchDescriptors returns the user supplied watch descriptors along with the default Module ones
 func (r Reconciler) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return r.WatchDescriptors
+	return append(r.GetDefaultWatchDescriptors(), r.WatchDescriptors...)
 }

--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -38,6 +38,16 @@ func (r Reconciler) Reconcile(spictx controllerspi.ReconcileContext, u *unstruct
 	}
 
 	if cr.Generation == cr.Status.LastSuccessfulGeneration {
+		// When the cr.Generation matches the status generation, then the
+		// spec config for that specific generation has been reconciled.
+		// However, even if the reconciliation (e.g. install) finishes,
+		// reconcile might still get called a few times because controller-runtime can have
+		// CR updates in its cache.  If the code was to continue to reconcile, then
+		// the update action would occur and the Module condition would have update reasons
+		// instead of install reasons (e.g. InstallComplete).
+		// Therefore, we only re-reconcile if a watch triggered reconcile because
+		// something changed (the watched resource).
+		//
 		return result.NewResult()
 	}
 

--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -167,14 +167,12 @@ func (r Reconciler) checkIfRequeueNeededWhenGenerationsMatch(module *moduleapi.M
 	// every resource that uses watches will reconcile (like Module).
 	// We can possibly remove this code when we optimize the module handlers. so they only call Helm
 	// when needed by using a hash on the manifests, or something like that.
-	//if watchEvent.WatchEventType == controllerspi.Created {
-	//	// Get the watched resource
-	//
-	//	if watchEvent.WatchedResource.GetCreationTimestamp().Time.Add(time.Second * 60).Before(time.Now()) {
-	//		return result.NewResult()
-	//	}
-	//}
-	//
+	if watchEvent.WatchEventType == controllerspi.Created {
+		if watchEvent.WatchedResource.GetCreationTimestamp().Time.Add(time.Second * 60).Before(time.Now()) {
+			return result.NewResult()
+		}
+	}
+
 	// At this point, there was an event that happened after the last reconcile, so another reconcile needs to be done
 	// Reset the last reconciled generation to zero so that we go through the normal reconcile loop
 	// Also, reset the state machine tracker for this CR generation

--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -42,11 +42,14 @@ func (r Reconciler) Reconcile(spictx controllerspi.ReconcileContext, u *unstruct
 		// spec config for that specific generation has been reconciled.
 		// However, even if the reconciliation (e.g. install) finishes,
 		// reconcile might still get called a few times because controller-runtime can have
-		// CR updates in its cache.  If the code was to continue to reconcile, then
-		// the update action would occur and the Module condition would have update reasons
+		// CR updates in its cache. Also, a watched resource may have triggered an event causing
+		// reconcile to be called.  If the code was to continue to reconcile when it was really done,
+		// then the update action would occur and the Module condition would have update reasons
 		// instead of install reasons (e.g. InstallComplete).
+		//
 		// Therefore, we only re-reconcile if a watch triggered reconcile because
-		// something changed (the watched resource).
+		// something changed (the watched resource).  Determine if we need to reconcile
+		// based on the watch event timestamps.
 		//
 		return result.NewResult()
 	}

--- a/module-operator/controllers/module/reconciler_test.go
+++ b/module-operator/controllers/module/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	moduleapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
 	"github.com/verrazzano/verrazzano-modules/module-operator/internal/statemachine"
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/basecontroller"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/handlerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
@@ -159,8 +160,10 @@ func TestReconcileSuccess(t *testing.T) {
 			scheme := initScheme()
 			clientBuilder := fakes.NewClientBuilder().WithScheme(scheme)
 			r := Reconciler{
-				Client:                 clientBuilder.Build(),
-				Scheme:                 initScheme(),
+				BaseReconciler: &basecontroller.BaseReconciler{
+					Client: clientBuilder.Build(),
+					Scheme: initScheme(),
+				},
 				ModuleControllerConfig: ModuleControllerConfig{ModuleHandlerInfo: test.moduleInfo},
 			}
 			uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
@@ -303,8 +306,10 @@ func TestReconcileErrors(t *testing.T) {
 			scheme := initScheme()
 			clientBuilder := fakes.NewClientBuilder().WithScheme(scheme)
 			r := Reconciler{
-				Client:                 clientBuilder.Build(),
-				Scheme:                 initScheme(),
+				BaseReconciler: &basecontroller.BaseReconciler{
+					Client: clientBuilder.Build(),
+					Scheme: initScheme(),
+				},
 				ModuleControllerConfig: ModuleControllerConfig{ModuleHandlerInfo: test.moduleInfo},
 			}
 			uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)

--- a/module-operator/controllers/module/status/status.go
+++ b/module-operator/controllers/module/status/status.go
@@ -30,6 +30,8 @@ var readyConditionMessages = map[moduleapi.ModuleConditionReason]string{
 	moduleapi.ReadyReasonUpgradeFailed:      "Failed upgrading Module `%s` as Helm release `%s/%s`: %v",
 }
 
+const timeFormat = "%d-%02d-%02dT%02d:%02d:%02dZ"
+
 // UpdateReadyConditionSucceeded updates the Ready condition when the module has succeeded
 func UpdateReadyConditionSucceeded(ctx handlerspi.HandlerContext, module *moduleapi.Module, reason moduleapi.ModuleConditionReason) result.Result {
 	module.Status.LastSuccessfulVersion = module.Spec.Version
@@ -128,6 +130,14 @@ func GetReadyCondition(cr *moduleapi.Module) *moduleapi.ModuleCondition {
 
 func getTransitionTime() string {
 	t := time.Now().UTC()
-	return fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02dZ",
+	return fmt.Sprintf(timeFormat,
 		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
+}
+
+func ParseTime(timestamp string) (time.Time, error) {
+	t, err := time.Parse(timeFormat, timestamp)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t, nil
 }

--- a/module-operator/controllers/module/watcher.go
+++ b/module-operator/controllers/module/watcher.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package module
+
+import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
+	corev1 "k8s.io/api/core/v1"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// GetDefaultWatchDescriptors returns the list of WatchDescriptors for objects being watched by the Module
+// Always for secrets and configmaps since they may contain module configuration
+func (r *Reconciler) GetDefaultWatchDescriptors() []controllerspi.WatchDescriptor {
+	return []controllerspi.WatchDescriptor{
+		{
+			WatchedResourceKind: source.Kind{Type: &corev1.Secret{}},
+			FuncShouldReconcile: r.ShouldSecretEventTriggerReconcile,
+		},
+		{
+			WatchedResourceKind: source.Kind{Type: &corev1.ConfigMap{}},
+			FuncShouldReconcile: r.ShouldConfigmapEventTriggerReconcile,
+		},
+	}
+}
+
+// ShouldSecretEventTriggerReconcile returns true if reconcile should be done in response to a Secret lifecycle event
+func (r *Reconciler) ShouldSecretEventTriggerReconcile(obj clipkg.Object, event controllerspi.WatchEvent) bool {
+	if event == controllerspi.Deleted {
+		return false
+	}
+	secret := obj.(*corev1.Secret)
+	return doesModuleOwnResource(secret.Labels, r.Name())
+}
+
+// ShouldConfigmapEventTriggerReconcile returns true if reconcile should be done in response to a Configmap lifecycle event
+func (r *Reconciler) ShouldConfigmapEventTriggerReconcile(obj clipkg.Object, event controllerspi.WatchEvent) bool {
+	if event == controllerspi.Deleted {
+		return false
+	}
+	cm := obj.(*corev1.ConfigMap)
+	return doesModuleOwnResource(cm.Labels, h.Name())
+}
+
+// doesModuleOwnResource returns true if the resource module owner label matches component
+func doesModuleOwnResource(labels map[string]string, moduleName string) bool {
+	if labels == nil {
+		return false
+	}
+	owner, ok := labels[constants.VerrazzanoModuleOwnerLabel]
+	if !ok {
+		return false
+	}
+	// return true if this resource has the module owner label that matches this component.
+	return owner == moduleName
+}

--- a/module-operator/controllers/module/watcher.go
+++ b/module-operator/controllers/module/watcher.go
@@ -29,7 +29,7 @@ func (r *Reconciler) GetDefaultWatchDescriptors() []controllerspi.WatchDescripto
 }
 
 // ShouldSecretTriggerReconcile returns true if reconcile should be done in response to a Secret lifecycle event
-func (r *Reconciler) ShouldSecretTriggerReconcile(moduleNSN types.NamespacedName, secret client.Object, _ controllerspi.WatchEvent) bool {
+func (r *Reconciler) ShouldSecretTriggerReconcile(moduleNSN types.NamespacedName, secret client.Object, _ controllerspi.WatchEventType) bool {
 	if secret.GetNamespace() != moduleNSN.Namespace {
 		return false
 	}
@@ -37,7 +37,7 @@ func (r *Reconciler) ShouldSecretTriggerReconcile(moduleNSN types.NamespacedName
 }
 
 // ShouldConfigMapTriggerReconcile returns true if reconcile should be done in response to a Secret lifecycle event
-func (r *Reconciler) ShouldConfigMapTriggerReconcile(moduleNSN types.NamespacedName, cm client.Object, _ controllerspi.WatchEvent) bool {
+func (r *Reconciler) ShouldConfigMapTriggerReconcile(moduleNSN types.NamespacedName, cm client.Object, _ controllerspi.WatchEventType) bool {
 	if cm.GetNamespace() != moduleNSN.Namespace {
 		return false
 	}

--- a/module-operator/internal/statemachine/statemachine.go
+++ b/module-operator/internal/statemachine/statemachine.go
@@ -24,6 +24,7 @@ import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/handlerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 // state identifies the state of a component during work
@@ -110,6 +111,7 @@ func (s *StateMachine) Execute(handlerContext handlerspi.HandlerContext) result.
 			tracker.state = statePreWork
 
 		case statePreWork:
+			tracker.preInstallTime = time.Now()
 			handlerContext.Log.Progressf("Doing pre-%s for %s", workerName, nsn)
 			res := s.Handler.PreWork(handlerContext)
 			if res.ShouldRequeue() {
@@ -166,4 +168,10 @@ func (s *StateMachine) Execute(handlerContext handlerspi.HandlerContext) result.
 		}
 	}
 	return result.NewResult()
+}
+
+// GetPreInstallTime returns the time right before preinstall is called
+func GetPreInstallTime(cr client.Object) *time.Time {
+	tracker := ensureTracker(cr, stateInit)
+	return &tracker.preInstallTime
 }

--- a/module-operator/internal/statemachine/tracker.go
+++ b/module-operator/internal/statemachine/tracker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/verrazzano/verrazzano-modules/pkg/vzlog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sync"
+	"time"
 )
 
 // stateTracker keeps an in-memory state for a ModuleCR execute the state machine.
@@ -15,6 +16,9 @@ type stateTracker struct {
 	state state
 	gen   int64
 	key   string
+
+	// preInstallTime tracks the time right before preInstall is called
+	preInstallTime time.Time
 }
 
 // trackerMap has a map of trackers with key from VZ name, namespace, and UID.

--- a/pkg/controller/base/basecontroller/controller.go
+++ b/pkg/controller/base/basecontroller/controller.go
@@ -23,12 +23,12 @@ import (
 // This code will always return a nil error, and will set the ctrl.Result.Requeue to true (with a delay) if a requeue is needed.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// Do some validation then get the GVK of the resource
-	if r.Reconciler == nil {
+	if r.layeredControllerConfig.Reconciler == nil {
 		err := errors.New("Failed, Reconciler interface in ControllerConfig must be implemented")
 		zap.S().Error(err)
 		return result.NewResultShortRequeueDelay().GetCtrlRuntimeResult(), err
 	}
-	ro := r.GetReconcileObject()
+	ro := r.layeredControllerConfig.GetReconcileObject()
 	if ro == nil {
 		err := errors.New("Failed, Reconciler.GetReconcileObject returns nil")
 		zap.S().Error(err)
@@ -36,7 +36,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	gvk, _, err := r.Scheme.ObjectKinds(ro)
 	if err != nil {
-		zap.S().Errorf("Failed to get object GVK for %v: %v", r.GetReconcileObject(), err)
+		zap.S().Errorf("Failed to get object GVK for %v: %v", r.layeredControllerConfig.GetReconcileObject(), err)
 		return result.NewResultShortRequeueDelay().GetCtrlRuntimeResult(), nil
 	}
 
@@ -45,9 +45,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	cr.SetGroupVersionKind(gvk[0])
 	if err := r.Get(ctx, req.NamespacedName, cr); err != nil {
 		// If the resource is not found, that means all the finalizers have been removed,
-		// and the Verrazzano resource has been deleted, so there is nothing left to do.
+		// and the  resource has been deleted, so there is nothing left to do.
 		if k8serrors.IsNotFound(err) {
-			r.removeControllerResource(req.NamespacedName)
 			return reconcile.Result{}, nil
 		}
 		zap.S().Errorf("Failed to fetch resource %v: %v", req.NamespacedName, err)
@@ -59,7 +58,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		Namespace:      cr.GetNamespace(),
 		ID:             string(cr.GetUID()),
 		Generation:     cr.GetGeneration(),
-		ControllerName: r.Reconciler.GetReconcileObject().GetObjectKind().GroupVersionKind().Kind,
+		ControllerName: r.layeredControllerConfig.Reconciler.GetReconcileObject().GetObjectKind().GroupVersionKind().Kind,
 	})
 	if err != nil {
 		zap.S().Errorf("Failed to create controller logger for DNS controller", err)
@@ -75,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Handle finalizer
-	if r.Finalizer != nil {
+	if r.layeredControllerConfig.Finalizer != nil {
 		// Make sure the ModuleCR has a finalizer
 		if cr.GetDeletionTimestamp().IsZero() {
 			if res := r.ensureFinalizer(log, cr); res.ShouldRequeue() {
@@ -83,7 +82,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 		} else {
 			// ModuleCR is being deleted
-			res := r.PreRemoveFinalizer(rctx, cr)
+			res := r.layeredControllerConfig.PreRemoveFinalizer(rctx, cr)
 			if res.ShouldRequeue() {
 				return res.GetCtrlRuntimeResult(), nil
 			}
@@ -94,23 +93,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 			// all done, ModuleCR will be deleted from etcd
 			log.Oncef("Successfully deleted resource %v, generation %v", req.NamespacedName, cr.GetGeneration())
-			r.PostRemoveFinalizer(rctx, cr)
-			r.removeControllerResource(req.NamespacedName)
+			r.layeredControllerConfig.PostRemoveFinalizer(rctx, cr)
 			return ctrl.Result{}, nil
 		}
 	}
 
-	if r.Watcher != nil {
-		// Only keep track of resources if a watcher is used
-		r.addControllerResource(req.NamespacedName)
-
+	if r.layeredControllerConfig.Watcher != nil {
 		if err := r.initWatches(log, req.NamespacedName); err != nil {
 			return result.NewResultShortRequeueDelay().GetCtrlRuntimeResult(), nil
 		}
 	}
 
 	// Call the layered controller to reconcile.
-	res := r.Reconciler.Reconcile(rctx, cr)
+	res := r.layeredControllerConfig.Reconciler.Reconcile(rctx, cr)
 	if err != nil {
 		return result.NewResultShortRequeueDelay().GetCtrlRuntimeResult(), nil
 	}
@@ -124,21 +119,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // Init the watches for this resource
-func (r *Reconciler) initWatches(log vzlog.VerrazzanoLogger, nsn types.NamespacedName) error {
-	if r.watchersInitialized {
+func (r *Reconciler) initWatches(log vzlog.VerrazzanoLogger, resourceNSN types.NamespacedName) error {
+	if _, ok := r.watcherMap[resourceNSN]; ok {
 		return nil
 	}
 
-	// Get all the kinds of objects that need to be watched
-	// For each object, create a watchContext and call the watcher to watch it
-	wds := r.Watcher.GetWatchDescriptors()
+	// For each object being watched, create a watchContext and call the watcher to watch it
+	wds := r.layeredControllerConfig.Watcher.GetWatchDescriptors()
 	for i := range wds {
 		w := &WatchContext{
-			Controller:                 r.Controller,
-			Log:                        log,
-			ResourceKind:               wds[i].WatchKind,
-			ShouldReconcile:            wds[i].FuncShouldReconcile,
-			FuncGetControllerResources: r.GetControllerResources,
+			Controller:              r.Controller,
+			Log:                     log,
+			watchDescriptor:         wds[i],
+			resourceBeingReconciled: resourceNSN,
 		}
 		err := w.Watch()
 		if err != nil {
@@ -147,13 +140,13 @@ func (r *Reconciler) initWatches(log vzlog.VerrazzanoLogger, nsn types.Namespace
 		r.watchContexts = append(r.watchContexts, w)
 	}
 
-	r.watchersInitialized = true
+	r.watcherMap[resourceNSN] = true
 	return nil
 }
 
 // ensureFinalizer ensures that a finalizer exists and updates the ModuleCR if it doesn't
 func (r *Reconciler) ensureFinalizer(log vzlog.VerrazzanoLogger, u *unstructured.Unstructured) result.Result {
-	finalizerName := r.Finalizer.GetName()
+	finalizerName := r.layeredControllerConfig.Finalizer.GetName()
 	finalizers := u.GetFinalizers()
 	if vzstring.SliceContainsString(finalizers, finalizerName) {
 		return result.NewResult()
@@ -171,7 +164,7 @@ func (r *Reconciler) ensureFinalizer(log vzlog.VerrazzanoLogger, u *unstructured
 
 // deleteFinalizer deletes the finalizer
 func (r *Reconciler) deleteFinalizer(log vzlog.VerrazzanoLogger, u *unstructured.Unstructured) error {
-	finalizerName := r.Finalizer.GetName()
+	finalizerName := r.layeredControllerConfig.Finalizer.GetName()
 	finalizers := u.GetFinalizers()
 	if !vzstring.SliceContainsString(finalizers, finalizerName) {
 		return nil
@@ -184,45 +177,4 @@ func (r *Reconciler) deleteFinalizer(log vzlog.VerrazzanoLogger, u *unstructured
 	}
 
 	return nil
-}
-
-// removeControllerResource removes a controller resource from the set
-func (r *Reconciler) removeControllerResource(nsn types.NamespacedName) {
-	if !r.controllerResourceExists(nsn) {
-		return
-	}
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	delete(r.controllerResources, nsn)
-}
-
-// addControllerResource adds a controller resource to the set
-func (r *Reconciler) addControllerResource(nsn types.NamespacedName) {
-	if r.controllerResourceExists(nsn) {
-		return
-	}
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	r.controllerResources[nsn] = true
-}
-
-// controllerResourceExists returns true if the resource is in the set
-func (r *Reconciler) controllerResourceExists(nsn types.NamespacedName) bool {
-	if r.controllerResources == nil {
-		return false
-	}
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	return r.controllerResources[nsn]
-}
-
-// GetControllerResources returns the list of controller resources
-func (r *Reconciler) GetControllerResources() []types.NamespacedName {
-	nsns := []types.NamespacedName{}
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	for k := range r.controllerResources {
-		nsns = append(nsns, k)
-	}
-	return nsns
 }

--- a/pkg/controller/base/basecontroller/controller.go
+++ b/pkg/controller/base/basecontroller/controller.go
@@ -22,16 +22,16 @@ import (
 // Reconcile the resource
 // The controller-runtime will call this method repeatedly if the ctrl.Result.Requeue is true, or an error is returned
 // This code will always return a nil error, and will set the ctrl.Result.Requeue to true (with a delay) if a requeue is needed.
-func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *BaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// Do some validation then get the GVK of the resource
 	if r.layeredControllerConfig.Reconciler == nil {
-		err := errors.New("Failed, Reconciler interface in ControllerConfig must be implemented")
+		err := errors.New("Failed, BaseReconciler interface in ControllerConfig must be implemented")
 		zap.S().Error(err)
 		return result.NewResultShortRequeueDelay().GetCtrlRuntimeResult(), err
 	}
 	ro := r.layeredControllerConfig.GetReconcileObject()
 	if ro == nil {
-		err := errors.New("Failed, Reconciler.GetReconcileObject returns nil")
+		err := errors.New("Failed, BaseReconciler.GetReconcileObject returns nil")
 		zap.S().Error(err)
 		return result.NewResultShortRequeueDelay().GetCtrlRuntimeResult(), err
 	}
@@ -120,7 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // Init the watches for this resource
-func (r *Reconciler) initWatches(log vzlog.VerrazzanoLogger, resourceNSN types.NamespacedName) error {
+func (r *BaseReconciler) initWatches(log vzlog.VerrazzanoLogger, resourceNSN types.NamespacedName) error {
 	r.watchMutex.Lock()
 	defer r.watchMutex.Unlock()
 	if _, ok := r.watcherInitMap[resourceNSN]; ok {
@@ -149,7 +149,7 @@ func (r *Reconciler) initWatches(log vzlog.VerrazzanoLogger, resourceNSN types.N
 }
 
 // ensureFinalizer ensures that a finalizer exists and updates the ModuleCR if it doesn't
-func (r *Reconciler) ensureFinalizer(log vzlog.VerrazzanoLogger, u *unstructured.Unstructured) result.Result {
+func (r *BaseReconciler) ensureFinalizer(log vzlog.VerrazzanoLogger, u *unstructured.Unstructured) result.Result {
 	finalizerName := r.layeredControllerConfig.Finalizer.GetName()
 	finalizers := u.GetFinalizers()
 	if vzstring.SliceContainsString(finalizers, finalizerName) {
@@ -167,7 +167,7 @@ func (r *Reconciler) ensureFinalizer(log vzlog.VerrazzanoLogger, u *unstructured
 }
 
 // deleteFinalizer deletes the finalizer
-func (r *Reconciler) deleteFinalizer(log vzlog.VerrazzanoLogger, u *unstructured.Unstructured) error {
+func (r *BaseReconciler) deleteFinalizer(log vzlog.VerrazzanoLogger, u *unstructured.Unstructured) error {
 	finalizerName := r.layeredControllerConfig.Finalizer.GetName()
 	finalizers := u.GetFinalizers()
 	if !vzstring.SliceContainsString(finalizers, finalizerName) {
@@ -184,14 +184,14 @@ func (r *Reconciler) deleteFinalizer(log vzlog.VerrazzanoLogger, u *unstructured
 }
 
 // Update the map entry for the resource with the current time
-func (r *Reconciler) updateWatchTimestamp(nsn types.NamespacedName) {
+func (r *BaseReconciler) updateWatchTimestamp(nsn types.NamespacedName) {
 	r.watchMutex.Lock()
 	defer r.watchMutex.Unlock()
 	r.watchEventTimestampMap[nsn] = time.Now()
 }
 
 // GetWatchTimestamp gets the map entry for the resource
-func (r *Reconciler) GetWatchTimestamp(nsn types.NamespacedName) *time.Time {
+func (r *BaseReconciler) GetWatchTimestamp(nsn types.NamespacedName) *time.Time {
 	r.watchMutex.Lock()
 	defer r.watchMutex.Unlock()
 	t, ok := r.watchEventTimestampMap[nsn]

--- a/pkg/controller/base/basecontroller/controller.go
+++ b/pkg/controller/base/basecontroller/controller.go
@@ -66,7 +66,7 @@ func (r *BaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return result.NewResultShortRequeueDelay().GetCtrlRuntimeResult(), nil
 	}
 
-	log.Progressf("Reconciling resource %v, GVK %v, generation %v", req.NamespacedName, gvk, cr.GetGeneration())
+	log.Debugf("Reconciling resource %v, GVK %v, generation %v", req.NamespacedName, gvk, cr.GetGeneration())
 
 	// Create a new context for this reconcile loop
 	rctx := controllerspi.ReconcileContext{
@@ -115,7 +115,7 @@ func (r *BaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// The resource has been reconciled.
-	log.Infof("Successfully reconciled resource %v", req.NamespacedName)
+	log.Debugf("Successfully reconciled resource %v", req.NamespacedName)
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller/base/basecontroller/controller_test.go
+++ b/pkg/controller/base/basecontroller/controller_test.go
@@ -106,7 +106,7 @@ func TestConcurrentReconcile(t *testing.T) {
 }
 
 // TestReconciler tests that the layered controller Reconcile interface works alone
-// GIVEN a controller that implements Reconciler interface
+// GIVEN a controller that implements BaseReconciler interface
 // WHEN Reconcile is called
 // THEN ensure that the controller returns success and that the Reconcile method is called
 func TestReconciler(t *testing.T) {
@@ -263,7 +263,7 @@ func TestDelete(t *testing.T) {
 }
 
 // TestReconcilerMissing tests that an error is returned when the reconciler implementation is missing
-// GIVEN a controller that implements Reconciler interface
+// GIVEN a controller that implements BaseReconciler interface
 // WHEN Reconcile is called
 // THEN ensure that the controller returns success
 func TestReconcilerMissing(t *testing.T) {
@@ -287,7 +287,7 @@ func TestReconcilerMissing(t *testing.T) {
 }
 
 // TestReconcilerGetObjectMissing tests that an error is returned
-// GIVEN a controller that implements Reconciler interface
+// GIVEN a controller that implements BaseReconciler interface
 // WHEN Reconcile is called and GetReconcileObject returns nil
 // THEN ensure that the controller returns and error
 func TestReconcilerGetObjectMissing(t *testing.T) {
@@ -313,7 +313,7 @@ func TestReconcilerGetObjectMissing(t *testing.T) {
 }
 
 // TestNotFound tests that the controller handles not found
-// GIVEN a controller that implements Reconciler interface
+// GIVEN a controller that implements BaseReconciler interface
 // WHEN Reconcile is called
 // THEN ensure that the controller returns success if ModuleCR doesn't exist
 func TestNotFound(t *testing.T) {
@@ -336,9 +336,9 @@ func TestNotFound(t *testing.T) {
 }
 
 // newReconciler creates a new reconciler for testing
-func newReconciler(c client.Client, controllerConfig ControllerConfig) *Reconciler {
+func newReconciler(c client.Client, controllerConfig ControllerConfig) *BaseReconciler {
 	scheme := newScheme()
-	reconciler := Reconciler{
+	reconciler := BaseReconciler{
 		Client:                  c,
 		Scheme:                  scheme,
 		layeredControllerConfig: controllerConfig,

--- a/pkg/controller/base/basecontroller/controller_test.go
+++ b/pkg/controller/base/basecontroller/controller_test.go
@@ -344,6 +344,7 @@ func newReconciler(c client.Client, controllerConfig ControllerConfig) *BaseReco
 		layeredControllerConfig: controllerConfig,
 		Controller:              fakeController{},
 		watcherInitMap:          make(map[types.NamespacedName]bool),
+		watchEvents:             make(map[types.NamespacedName]*controllerspi.WatchEvent),
 	}
 	return &reconciler
 }

--- a/pkg/controller/base/basecontroller/controller_test.go
+++ b/pkg/controller/base/basecontroller/controller_test.go
@@ -343,7 +343,7 @@ func newReconciler(c client.Client, controllerConfig ControllerConfig) *Reconcil
 		Scheme:                  scheme,
 		layeredControllerConfig: controllerConfig,
 		Controller:              fakeController{},
-		watcherMap:              make(map[types.NamespacedName]bool),
+		watcherInitMap:          make(map[types.NamespacedName]bool),
 	}
 	return &reconciler
 }

--- a/pkg/controller/base/basecontroller/manager.go
+++ b/pkg/controller/base/basecontroller/manager.go
@@ -11,6 +11,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"time"
 )
 
 // CreateControllerAndAddItToManager creates the base controller and adds it to the manager.
@@ -19,7 +20,8 @@ func CreateControllerAndAddItToManager(mgr controllerruntime.Manager, controller
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
 		layeredControllerConfig: controllerConfig,
-		watcherMap:              make(map[types.NamespacedName]bool),
+		watcherInitMap:          make(map[types.NamespacedName]bool),
+		watchEventTimestampMap:  make(map[types.NamespacedName]time.Time),
 	}
 
 	// Create the controller and add it to the manager (Build does an implicit add)

--- a/pkg/controller/base/basecontroller/manager.go
+++ b/pkg/controller/base/basecontroller/manager.go
@@ -11,7 +11,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"time"
 )
 
 // CreateControllerAndAddItToManager creates the base controller and adds it to the manager.
@@ -21,7 +20,7 @@ func CreateControllerAndAddItToManager(mgr controllerruntime.Manager, controller
 		Scheme:                  mgr.GetScheme(),
 		layeredControllerConfig: controllerConfig,
 		watcherInitMap:          make(map[types.NamespacedName]bool),
-		watchEventTimestampMap:  make(map[types.NamespacedName]time.Time),
+		watchEvents:             make(map[types.NamespacedName]*controllerspi.WatchEvent),
 	}
 
 	// Create the controller and add it to the manager (Build does an implicit add)

--- a/pkg/controller/base/basecontroller/manager.go
+++ b/pkg/controller/base/basecontroller/manager.go
@@ -15,8 +15,8 @@ import (
 )
 
 // CreateControllerAndAddItToManager creates the base controller and adds it to the manager.
-func CreateControllerAndAddItToManager(mgr controllerruntime.Manager, controllerConfig ControllerConfig) (*Reconciler, error) {
-	r := Reconciler{
+func CreateControllerAndAddItToManager(mgr controllerruntime.Manager, controllerConfig ControllerConfig) (*BaseReconciler, error) {
+	r := BaseReconciler{
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
 		layeredControllerConfig: controllerConfig,
@@ -43,7 +43,7 @@ func CreateControllerAndAddItToManager(mgr controllerruntime.Manager, controller
 	return &r, nil
 }
 
-func (r *Reconciler) createPredicateFilter(filter controllerspi.EventFilter) predicate.Predicate {
+func (r *BaseReconciler) createPredicateFilter(filter controllerspi.EventFilter) predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return filter.HandlePredicateEvent(r.Client, e.Object)

--- a/pkg/controller/base/basecontroller/manager.go
+++ b/pkg/controller/base/basecontroller/manager.go
@@ -6,50 +6,20 @@ package basecontroller
 import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano-modules/pkg/vzlog"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sync"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
-
-// ControllerConfig specifies the config of the controller using this base controller
-type ControllerConfig struct {
-	controllerspi.Finalizer
-	controllerspi.Reconciler
-	controllerspi.EventFilter
-	controllerspi.Watcher
-}
-
-// Reconciler contains data needed to reconcile a DNS object.
-type Reconciler struct {
-	client.Client
-	Scheme     *runtime.Scheme
-	Controller controller.Controller
-	ControllerConfig
-	watchersInitialized bool
-	watchContexts       []*WatchContext
-
-	// controllerResources contains a set of CRs for this controller that exist.
-	// It is important that resources get added to this set during the base controller reconcile loop, as
-	// well as removed when the resource is deleted.
-	controllerResources map[types.NamespacedName]bool
-	mutex               sync.RWMutex
-}
 
 // CreateControllerAndAddItToManager creates the base controller and adds it to the manager.
 func CreateControllerAndAddItToManager(mgr controllerruntime.Manager, controllerConfig ControllerConfig) (*Reconciler, error) {
 	r := Reconciler{
-		Client:              mgr.GetClient(),
-		Scheme:              mgr.GetScheme(),
-		ControllerConfig:    controllerConfig,
-		controllerResources: make(map[types.NamespacedName]bool),
-		mutex:               sync.RWMutex{},
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		layeredControllerConfig: controllerConfig,
+		watcherMap:              make(map[types.NamespacedName]bool),
 	}
 
 	// Create the controller and add it to the manager (Build does an implicit add)

--- a/pkg/controller/base/basecontroller/manager_test.go
+++ b/pkg/controller/base/basecontroller/manager_test.go
@@ -66,7 +66,7 @@ func TestCreatePredicateFilter(t *testing.T) {
 			clientBuilder := fakes.NewClientBuilder()
 			c := clientBuilder.WithScheme(newScheme()).WithObjects(cr).Build()
 			r := newReconciler(c, config)
-			f := r.createPredicateFilter(r.EventFilter)
+			f := r.createPredicateFilter(r.layeredControllerConfig.EventFilter)
 
 			asserts.NotNil(f.Create)
 			asserts.NotNil(f.Delete)

--- a/pkg/controller/base/basecontroller/types.go
+++ b/pkg/controller/base/basecontroller/types.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package basecontroller
+
+import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
+	"github.com/verrazzano/verrazzano-modules/pkg/vzlog"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sync/atomic"
+)
+
+// ControllerConfig specifies the config of the controller using this base controller
+type ControllerConfig struct {
+	controllerspi.Finalizer
+	controllerspi.Reconciler
+	controllerspi.EventFilter
+	controllerspi.Watcher
+}
+
+// Reconciler contains data needed to reconcile a DNS object.
+type Reconciler struct {
+	// Client is the controller-runtime client
+	client.Client
+
+	// Scheme is the CR scheme
+	Scheme     *runtime.Scheme
+
+	// Controller is a controller-runtime controller
+	Controller controller.Controller
+
+	// layeredControllerConfig config is the layered controller
+	layeredControllerConfig ControllerConfig
+
+	// WatchEventOccurred is a toggle to indicate that a watch has occurred. Once it is reconciled, then it is cleared.
+	WatchEventOccurred atomic.Bool
+
+	// watcherMap is used to determine if a watches have been initialized for the CR instance
+	watcherMap         map[types.NamespacedName]bool
+
+	// watchContexts is the list of watchContexts, one for each watch
+	watchContexts      []*WatchContext
+}
+
+// WatchContext provides context to a watcher
+// There is a WatchContext for each resource being watched by each instance of a CR.
+type WatchContext struct {
+	// Controller is a controller-runtime controller
+	Controller              controller.Controller
+
+	// Log is the Verrazzano logger
+	Log                     vzlog.VerrazzanoLogger
+
+	// watchDescriptor describes the resource being watched
+	watchDescriptor 	controllerspi.WatchDescriptor
+
+	// resourceBeingReconciled is the resource being reconciled
+	resourceBeingReconciled types.NamespacedName
+}

--- a/pkg/controller/base/basecontroller/types.go
+++ b/pkg/controller/base/basecontroller/types.go
@@ -22,8 +22,8 @@ type ControllerConfig struct {
 	controllerspi.Watcher
 }
 
-// Reconciler contains data needed to reconcile a DNS object.
-type Reconciler struct {
+// BaseReconciler contains data needed to reconcile a DNS object.
+type BaseReconciler struct {
 	// Client is the controller-runtime client
 	client.Client
 
@@ -55,8 +55,8 @@ type WatchContext struct {
 	// Controller is a controller-runtime controller
 	controller controller.Controller
 
-	// Reconciler is the base reconciler that created this WatchContext
-	reconciler *Reconciler
+	// BaseReconciler is the base reconciler that created this WatchContext
+	reconciler *BaseReconciler
 
 	// Log is the Verrazzano logger
 	log vzlog.VerrazzanoLogger

--- a/pkg/controller/base/basecontroller/types.go
+++ b/pkg/controller/base/basecontroller/types.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sync"
-	"time"
 )
 
 // ControllerConfig specifies the config of the controller using this base controller
@@ -42,8 +41,8 @@ type BaseReconciler struct {
 	// watchContexts is the list of watchContexts, one for each watch
 	watchContexts []*WatchContext
 
-	// watchEventTimestampMap is used to record the latest watch event timestamp that caused a reconcile event
-	watchEventTimestampMap map[types.NamespacedName]time.Time
+	// watchEvents is used to record the latest watch event for a given resource being reconciled
+	watchEvents map[types.NamespacedName]*controllerspi.WatchEvent
 
 	// WatchMutex is used to control concurrent access the maps
 	watchMutex sync.Mutex

--- a/pkg/controller/base/basecontroller/types.go
+++ b/pkg/controller/base/basecontroller/types.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sync/atomic"
 )
 
 // ControllerConfig specifies the config of the controller using this base controller
@@ -27,7 +26,7 @@ type Reconciler struct {
 	client.Client
 
 	// Scheme is the CR scheme
-	Scheme     *runtime.Scheme
+	Scheme *runtime.Scheme
 
 	// Controller is a controller-runtime controller
 	Controller controller.Controller
@@ -35,27 +34,24 @@ type Reconciler struct {
 	// layeredControllerConfig config is the layered controller
 	layeredControllerConfig ControllerConfig
 
-	// WatchEventOccurred is a toggle to indicate that a watch has occurred. Once it is reconciled, then it is cleared.
-	WatchEventOccurred atomic.Bool
-
 	// watcherMap is used to determine if a watches have been initialized for the CR instance
-	watcherMap         map[types.NamespacedName]bool
+	watcherMap map[types.NamespacedName]bool
 
 	// watchContexts is the list of watchContexts, one for each watch
-	watchContexts      []*WatchContext
+	watchContexts []*WatchContext
 }
 
 // WatchContext provides context to a watcher
 // There is a WatchContext for each resource being watched by each instance of a CR.
 type WatchContext struct {
 	// Controller is a controller-runtime controller
-	Controller              controller.Controller
+	Controller controller.Controller
 
 	// Log is the Verrazzano logger
-	Log                     vzlog.VerrazzanoLogger
+	Log vzlog.VerrazzanoLogger
 
 	// watchDescriptor describes the resource being watched
-	watchDescriptor 	controllerspi.WatchDescriptor
+	watchDescriptor controllerspi.WatchDescriptor
 
 	// resourceBeingReconciled is the resource being reconciled
 	resourceBeingReconciled types.NamespacedName

--- a/pkg/controller/base/basecontroller/watcher.go
+++ b/pkg/controller/base/basecontroller/watcher.go
@@ -53,6 +53,7 @@ func (w *WatchContext) Watch() error {
 func (w *WatchContext) createReconcileEventHandler() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(
 		func(a client.Object) []reconcile.Request {
+			w.reconciler.updateWatchTimestamp(w.resourceBeingReconciled)
 			requests := []reconcile.Request{}
 			requests = append(requests, reconcile.Request{
 				NamespacedName: w.resourceBeingReconciled})

--- a/pkg/controller/base/basecontroller/watcher.go
+++ b/pkg/controller/base/basecontroller/watcher.go
@@ -5,28 +5,12 @@ package basecontroller
 
 import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
-	"github.com/verrazzano/verrazzano-modules/pkg/vzlog"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
-
-// FuncGetControllerResources is a type of function that resources the CRs that exist which are managed bu the controller
-type FuncGetControllerResources func() []types.NamespacedName
-
-// WatchContext provides context to a watcher
-type WatchContext struct {
-	Controller      controller.Controller
-	Log             vzlog.VerrazzanoLogger
-	ResourceKind    source.Kind
-	ShouldReconcile controllerspi.FuncShouldReconcile
-	FuncGetControllerResources
-}
 
 // Watch for a specific resource type
 func (w *WatchContext) Watch() error {
@@ -55,33 +39,30 @@ func (w *WatchContext) Watch() error {
 	// return a Watch with the predicate that is called in the future when a resource
 	// event occurs.  If the predicate returns true. then the reconciler loop will be called
 	return w.Controller.Watch(
-		&w.ResourceKind,
+		&w.watchDescriptor.WatchedResourceKind,
 		w.createReconcileEventHandler(),
 		p)
 }
 
 // createReconcileEventHandler creates an event handler that will get called
-// when a watched event results in a true predicate.  Each ModuleCR resource that this controller
-// manages (meaning it exists) will be in the WatcherContext.reconcileResources list.
-// A reconcile.Request will be returned for each resource, causing the controller-runtime
+// when a watched event results in a true predicate.  The ModuleCR resource that this controller
+// manages (meaning it exists) will be in the WatcherContext.
+// A reconcile Request will be returned, causing the controller-runtime
 // to call Reconcile for that resource.
 func (w *WatchContext) createReconcileEventHandler() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(
 		func(a client.Object) []reconcile.Request {
 			requests := []reconcile.Request{}
-			resources := w.FuncGetControllerResources()
-			for i := range resources {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: resources[i]})
-			}
+			requests = append(requests, reconcile.Request{
+				NamespacedName: w.resourceBeingReconciled})
 			return requests
 		})
 }
 
 // If the watched resource event should cause reconcile then return true
 func (w *WatchContext) shouldReconcile(watchedResource client.Object, ev controllerspi.WatchEvent) bool {
-	if w.ShouldReconcile == nil {
+	if w.watchDescriptor.FuncShouldReconcile == nil {
 		return false
 	}
-	return w.ShouldReconcile(watchedResource, ev)
+	return w.watchDescriptor.FuncShouldReconcile(watchedResource, ev)
 }

--- a/pkg/controller/base/basecontroller/watcher.go
+++ b/pkg/controller/base/basecontroller/watcher.go
@@ -33,7 +33,7 @@ func (w *WatchContext) Watch() error {
 		// a watched resource just got deleted
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			w.log.Infof("Watcher `delete` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
-			return w.shouldReconcile(e.Object, controllerspi.Deleted)
+			return w.shouldReconcile(e.Object, controllerspi.Deleted, w.resourceBeingReconciled)
 		},
 	}
 	// return a Watch with the predicate that is called in the future when a resource

--- a/pkg/controller/base/basecontroller/watcher.go
+++ b/pkg/controller/base/basecontroller/watcher.go
@@ -19,7 +19,7 @@ func (w *WatchContext) Watch() error {
 	p := predicate.Funcs{
 		// a watched resource just got created
 		CreateFunc: func(e event.CreateEvent) bool {
-			w.Log.Infof("Watcher `create` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
+			w.log.Infof("Watcher `create` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
 			return w.shouldReconcile(e.Object, controllerspi.Created)
 		},
 		// a watched resource just got updated
@@ -27,18 +27,18 @@ func (w *WatchContext) Watch() error {
 			if e.ObjectOld == e.ObjectNew {
 				return false
 			}
-			w.Log.Infof("Watcher `update` event occurred for watched  resource %s/%s", e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
+			w.log.Infof("Watcher `update` event occurred for watched  resource %s/%s", e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
 			return w.shouldReconcile(e.ObjectNew, controllerspi.Updated)
 		},
 		// a watched resource just got deleted
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			w.Log.Infof("Watcher `delete` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
+			w.log.Infof("Watcher `delete` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
 			return w.shouldReconcile(e.Object, controllerspi.Deleted)
 		},
 	}
 	// return a Watch with the predicate that is called in the future when a resource
 	// event occurs.  If the predicate returns true. then the reconciler loop will be called
-	return w.Controller.Watch(
+	return w.controller.Watch(
 		&w.watchDescriptor.WatchedResourceKind,
 		w.createReconcileEventHandler(),
 		p)

--- a/pkg/controller/base/basecontroller/watcher.go
+++ b/pkg/controller/base/basecontroller/watcher.go
@@ -21,7 +21,7 @@ func (w *WatchContext) Watch() error {
 	p := predicate.Funcs{
 		// a watched resource just got created
 		CreateFunc: func(e event.CreateEvent) bool {
-			w.log.Infof("Watcher `create` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
+			w.log.Debugf("Watcher `create` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
 			return w.shouldReconcile(w.resourceBeingReconciled, e.Object, controllerspi.Created)
 		},
 		// a watched resource just got updated
@@ -29,12 +29,12 @@ func (w *WatchContext) Watch() error {
 			if e.ObjectOld == e.ObjectNew {
 				return false
 			}
-			w.log.Infof("Watcher `update` event occurred for watched  resource %s/%s", e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
+			w.log.Debugf("Watcher `update` event occurred for watched  resource %s/%s", e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
 			return w.shouldReconcile(w.resourceBeingReconciled, e.ObjectNew, controllerspi.Updated)
 		},
 		// a watched resource just got deleted
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			w.log.Infof("Watcher `delete` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
+			w.log.Debugf("Watcher `delete` occurred for watched resource %s/%s", e.Object.GetNamespace(), e.Object.GetName())
 			return w.shouldReconcile(w.resourceBeingReconciled, e.Object, controllerspi.Deleted)
 		},
 	}

--- a/pkg/controller/base/basecontroller/watcher.go
+++ b/pkg/controller/base/basecontroller/watcher.go
@@ -72,7 +72,7 @@ func (w *WatchContext) shouldReconcile(resourceBeingReconciled types.NamespacedN
 	// Ignore the Create event if the creation timestamp is older than 30 seconds, otherwise
 	// every resource that uses watches will reconcile (like Module)
 	if ev == controllerspi.Created {
-		if watchedResource.GetCreationTimestamp().Time.Add(time.Second * 30).Before(time.Now()) {
+		if watchedResource.GetCreationTimestamp().Time.Add(time.Second * 60).Before(time.Now()) {
 			return false
 		}
 	}

--- a/pkg/controller/base/basecontroller/watcher_test.go
+++ b/pkg/controller/base/basecontroller/watcher_test.go
@@ -79,8 +79,8 @@ func TestWatch(t *testing.T) {
 				nsn:       nsn,
 			}
 			w := &WatchContext{
-				Controller:              c,
-				Log:                     vzlog.DefaultLogger(),
+				controller:              c,
+				log:                     vzlog.DefaultLogger(),
 				resourceBeingReconciled: nsn,
 				watchDescriptor: controllerspi.WatchDescriptor{
 					WatchedResourceKind: source.Kind{Type: &moduleapi.Module{}},

--- a/pkg/controller/base/basecontroller/watcher_test.go
+++ b/pkg/controller/base/basecontroller/watcher_test.go
@@ -112,7 +112,7 @@ func (w watchController) Watch(src source.Source, eventhandler handler.EventHand
 	return nil
 }
 
-func (w watchController) shouldReconcile(object client.Object, event controllerspi.WatchEvent) bool {
+func (w watchController) shouldReconcile(resourceBeingReconciled types.NamespacedName, object client.Object, event controllerspi.WatchEvent) bool {
 	return w.predicate
 }
 

--- a/pkg/controller/base/basecontroller/watcher_test.go
+++ b/pkg/controller/base/basecontroller/watcher_test.go
@@ -82,6 +82,8 @@ func TestWatch(t *testing.T) {
 				controller:              c,
 				log:                     vzlog.DefaultLogger(),
 				resourceBeingReconciled: nsn,
+				reconciler: newReconciler(nil, ControllerConfig{
+				}),
 				watchDescriptor: controllerspi.WatchDescriptor{
 					WatchedResourceKind: source.Kind{Type: &moduleapi.Module{}},
 					FuncShouldReconcile: c.shouldReconcile,
@@ -112,7 +114,7 @@ func (w watchController) Watch(src source.Source, eventhandler handler.EventHand
 	return nil
 }
 
-func (w watchController) shouldReconcile(resourceBeingReconciled types.NamespacedName, object client.Object, event controllerspi.WatchEvent) bool {
+func (w watchController) shouldReconcile(resourceBeingReconciled types.NamespacedName, object client.Object, event controllerspi.WatchEventType) bool {
 	return w.predicate
 }
 

--- a/pkg/controller/base/controllerspi/controllerspi.go
+++ b/pkg/controller/base/controllerspi/controllerspi.go
@@ -8,12 +8,13 @@ import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
 	"github.com/verrazzano/verrazzano-modules/pkg/vzlog"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // FuncShouldReconcile returns true if the watched object event should trigger reconcile
-type FuncShouldReconcile func(object client.Object, event WatchEvent) bool
+type FuncShouldReconcile func(reconciledResource types.NamespacedName, watchedObject client.Object, event WatchEvent) bool
 
 // FuncControllerEventFilter is the predicate event handler filter that returns true if the object should be reconciled.
 // This is needed to use same CR for multiple controllers

--- a/pkg/controller/base/controllerspi/controllerspi.go
+++ b/pkg/controller/base/controllerspi/controllerspi.go
@@ -34,7 +34,9 @@ const (
 
 // WatchDescriptor described an object being watched
 type WatchDescriptor struct {
-	WatchKind source.Kind
+	// WatchedResourceKind is the kind of resource being watched
+	WatchedResourceKind source.Kind
+	// FuncShouldReconcile is called when watch event occurs to determine if CR should be reconciled
 	FuncShouldReconcile
 }
 

--- a/pkg/controller/base/controllerspi/controllerspi.go
+++ b/pkg/controller/base/controllerspi/controllerspi.go
@@ -11,39 +11,60 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"time"
 )
 
 // FuncShouldReconcile returns true if the watched object event should trigger reconcile
-type FuncShouldReconcile func(reconciledResource types.NamespacedName, watchedObject client.Object, event WatchEvent) bool
+type FuncShouldReconcile func(reconciledResource types.NamespacedName, watchedObject client.Object, event WatchEventType) bool
 
 // FuncControllerEventFilter is the predicate event handler filter that returns true if the object should be reconciled.
 // This is needed to use same CR for multiple controllers
 type FuncControllerEventFilter func(cli client.Client, object client.Object) bool
 
-type WatchEvent int
+// WatchEventType is the type of watched event
+type WatchEventType int
 
 const (
 	// Created indicates the watched object was created
-	Created WatchEvent = iota
+	Created WatchEventType = iota
 
 	// Updated indicates the watched object was updated
-	Updated WatchEvent = iota
+	Updated WatchEventType = iota
 
 	// Deleted indicates the watched object was deleted
-	Deleted WatchEvent = iota
+	Deleted WatchEventType = iota
 )
 
 // WatchDescriptor described an object being watched
 type WatchDescriptor struct {
 	// WatchedResourceKind is the kind of resource being watched
 	WatchedResourceKind source.Kind
+
 	// FuncShouldReconcile is called when watch event occurs to determine if CR should be reconciled
 	FuncShouldReconcile
 }
 
+// WatchEvent is an occurrence of a watch event
+type WatchEvent struct {
+	// WatchEventType is the type of watched event
+	WatchEventType
+
+	// EventTime is the time the event occurred
+	EventTime time.Time
+
+	// WatchedResource is the resource that caused the event
+	WatchedResource client.Object
+
+	// ReconcilingResource is the resource that is potentially being reconciled
+	ReconcilingResource types.NamespacedName
+}
+
 // ReconcileContext is a context has the dynamic context needed for a reconcile operation
 type ReconcileContext struct {
-	Log       vzlog.VerrazzanoLogger
+	// Log is the VerrazzanoLogger
+	Log vzlog.VerrazzanoLogger
+
+	// ClientCtx is the context used to make controller runtime client API calls
 	ClientCtx context.Context
 }
 

--- a/pkg/controller/result/builder.go
+++ b/pkg/controller/result/builder.go
@@ -34,7 +34,7 @@ func (b *builder) Delay(min int, max int, units time.Duration) Builder {
 }
 
 func (b *builder) ShortDelay() Builder {
-	return b.Delay(1, 2, time.Second)
+	return b.Delay(200, 500, time.Millisecond)
 }
 
 func (b *builder) Error(err error) Builder {

--- a/pkg/controller/result/builder_test.go
+++ b/pkg/controller/result/builder_test.go
@@ -52,8 +52,8 @@ func TestBuildShortDelay(t *testing.T) {
 	asserts.False(r.IsError())
 	asserts.NoError(r.GetError())
 	asserts.True(r.ShouldRequeue())
-	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(1) * time.Second).Seconds())
-	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(2) * time.Second).Seconds())
+	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(200) * time.Millisecond).Seconds())
+	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(500) * time.Millisecond).Seconds())
 }
 
 // TestBuildDelay tests the Delay builder method
@@ -97,6 +97,6 @@ func TestBuildAll(t *testing.T) {
 	asserts.True(r.ShouldRequeue())
 	asserts.True(r.IsError())
 	asserts.Equal(err2, r.GetError())
-	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(1) * time.Second).Seconds())
-	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(2) * time.Second).Seconds())
+	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(200) * time.Millisecond).Seconds())
+	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(500) * time.Millisecond).Seconds())
 }

--- a/pkg/controller/result/result_test.go
+++ b/pkg/controller/result/result_test.go
@@ -30,8 +30,8 @@ func TestNewResultShortRequeueDelay(t *testing.T) {
 	asserts := assert.New(t)
 	r := NewResultShortRequeueDelay()
 	asserts.True(r.ShouldRequeue())
-	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(1) * time.Second).Seconds())
-	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(2) * time.Second).Seconds())
+	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(200) * time.Millisecond).Seconds())
+	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(500) * time.Millisecond).Seconds())
 }
 
 // TestNewResultShortRequeueDelayWithError tests the NewResultShortRequeueDelayWithError method
@@ -49,8 +49,8 @@ func TestNewResultShortRequeueDelayWithError(t *testing.T) {
 	asserts.True(r.ShouldRequeue())
 	asserts.True(r.IsError())
 	asserts.Error(r.GetError())
-	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(1) * time.Second).Seconds())
-	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(2) * time.Second).Seconds())
+	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(200) * time.Millisecond).Seconds())
+	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(500) * time.Millisecond).Seconds())
 }
 
 // TestNewResultShortRequeueDelayIfError tests the NewResultShortRequeueDelayIfError method
@@ -68,8 +68,8 @@ func TestNewResultShortRequeueDelayIfError(t *testing.T) {
 	asserts.True(r.ShouldRequeue())
 	asserts.True(r.IsError())
 	asserts.Error(r.GetError())
-	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(1) * time.Second).Seconds())
-	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(2) * time.Second).Seconds())
+	asserts.GreaterOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(200) * time.Millisecond).Seconds())
+	asserts.LessOrEqual(r.GetCtrlRuntimeResult().RequeueAfter.Seconds(), (time.Duration(500) * time.Millisecond).Seconds())
 }
 
 // TestNewResultRequeueDelay tests the NewResultRequeueDelay func for the following use case


### PR DESCRIPTION
1. Refactor the base controller watches
2. Each watch context is now per CR Namespaced Names
3. Save latest WatchEvent
4. Add module watch for secrets and configmaps
5. Clean up SPI, add comments
6. Shorten the short requeue delay
7. Change module reconcile to process watch events with generation already matches status generation