### PR TITLE
VZ-10544 watch spi - pass in more info to watcher

### DIFF
--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -183,7 +183,7 @@ func (r Reconciler) checkIfRequeueNeededWhenGenerationsMatch(module *moduleapi.M
 	// We can possibly remove this code when we optimize the module handlers. so they only call Helm
 	// when needed by using a hash on the manifests, or something like that.
 	if watchEvent.WatchEventType == controllerspi.Created {
-		if watchEvent.WatchedResource.GetCreationTimestamp().Time.Add(time.Second * 60).Before(time.Now()) {
+		if watchEvent.NewWatchedObject.GetCreationTimestamp().Time.Add(time.Second * 60).Before(time.Now()) {
 			return result.NewResult()
 		}
 	}

--- a/module-operator/controllers/module/watcher.go
+++ b/module-operator/controllers/module/watcher.go
@@ -29,7 +29,7 @@ func (r *Reconciler) GetDefaultWatchDescriptors() []controllerspi.WatchDescripto
 }
 
 // ShouldSecretTriggerReconcile returns true if reconcile should be done in response to a Secret lifecycle event
-func (r *Reconciler) ShouldSecretTriggerReconcile(moduleNSN types.NamespacedName, secret client.Object, _ controllerspi.WatchEventType) bool {
+func (r *Reconciler) ShouldSecretTriggerReconcile(moduleNSN types.NamespacedName, secret client.Object, _ client.Object, _ controllerspi.WatchEventType) bool {
 	if secret.GetNamespace() != moduleNSN.Namespace {
 		return false
 	}
@@ -37,7 +37,7 @@ func (r *Reconciler) ShouldSecretTriggerReconcile(moduleNSN types.NamespacedName
 }
 
 // ShouldConfigMapTriggerReconcile returns true if reconcile should be done in response to a Secret lifecycle event
-func (r *Reconciler) ShouldConfigMapTriggerReconcile(moduleNSN types.NamespacedName, cm client.Object, _ controllerspi.WatchEventType) bool {
+func (r *Reconciler) ShouldConfigMapTriggerReconcile(moduleNSN types.NamespacedName, cm client.Object, _ client.Object, _ controllerspi.WatchEventType) bool {
 	if cm.GetNamespace() != moduleNSN.Namespace {
 		return false
 	}

--- a/module-operator/controllers/module/watcher.go
+++ b/module-operator/controllers/module/watcher.go
@@ -13,6 +13,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+type configType string
+
+const (
+	secretType    = "secretType"
+	configMapType = "configMapType"
+)
+
 // GetDefaultWatchDescriptors returns the list of WatchDescriptors for objects being watched by the Module
 // Always for secrets and configmaps since they may contain module configuration
 func (r *Reconciler) GetDefaultWatchDescriptors() []controllerspi.WatchDescriptor {
@@ -29,34 +36,34 @@ func (r *Reconciler) GetDefaultWatchDescriptors() []controllerspi.WatchDescripto
 }
 
 // ShouldSecretTriggerReconcile returns true if reconcile should be done in response to a Secret lifecycle event
-func (r *Reconciler) ShouldSecretTriggerReconcile(moduleNSN types.NamespacedName, secret client.Object, _ client.Object, _ controllerspi.WatchEventType) bool {
-	if secret.GetNamespace() != moduleNSN.Namespace {
+func (r *Reconciler) ShouldSecretTriggerReconcile(cli client.Client, wev controllerspi.WatchEvent) bool {
+	if wev.NewWatchedObject.GetNamespace() != wev.ReconcilingResource.Namespace {
 		return false
 	}
-	return r.shouldReconcile(moduleNSN, secret.GetName(), "")
+	return r.shouldReconcile(wev.ReconcilingResource, wev.NewWatchedObject.GetName(), secretType)
 }
 
 // ShouldConfigMapTriggerReconcile returns true if reconcile should be done in response to a Secret lifecycle event
-func (r *Reconciler) ShouldConfigMapTriggerReconcile(moduleNSN types.NamespacedName, cm client.Object, _ client.Object, _ controllerspi.WatchEventType) bool {
-	if cm.GetNamespace() != moduleNSN.Namespace {
+func (r *Reconciler) ShouldConfigMapTriggerReconcile(cli client.Client, wev controllerspi.WatchEvent) bool {
+	if wev.NewWatchedObject.GetNamespace() != wev.ReconcilingResource.Namespace {
 		return false
 	}
-	return r.shouldReconcile(moduleNSN, cm.GetName(), "")
+	return r.shouldReconcile(wev.ReconcilingResource, wev.NewWatchedObject.GetName(), configMapType)
 }
 
 // shouldReconcile returns true if reconcile should be done in response to a Secret or ConfigMap lifecycle event
 // Only reconcile if this module has those secret or configmap names in the module spec
-func (r *Reconciler) shouldReconcile(moduleNSN types.NamespacedName, secretName string, cmName string) bool {
+func (r *Reconciler) shouldReconcile(moduleNSN types.NamespacedName, resName string, cType configType) bool {
 	module := moduleapi.Module{}
 	if err := r.Get(context.TODO(), moduleNSN, &module); err != nil {
 		return false
 	}
 	// Check if the secret is in the valuesFrom
 	for _, vf := range module.Spec.ValuesFrom {
-		if vf.SecretRef != nil && secretName != "" && vf.SecretRef.Name == secretName {
+		if vf.SecretRef != nil && cType != secretType && vf.SecretRef.Name == resName {
 			return true
 		}
-		if vf.ConfigMapRef != nil && cmName != "" && vf.ConfigMapRef.Name == cmName {
+		if vf.ConfigMapRef != nil && cType != configMapType && vf.ConfigMapRef.Name == resName {
 			return true
 		}
 	}

--- a/pkg/controller/base/basecontroller/controller.go
+++ b/pkg/controller/base/basecontroller/controller.go
@@ -15,9 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 )
 
 // Reconcile the resource
@@ -185,15 +183,10 @@ func (r *BaseReconciler) deleteFinalizer(log vzlog.VerrazzanoLogger, u *unstruct
 }
 
 // updateWatchEventOccurrence Update the map entry for the resource with the current time
-func (r *BaseReconciler) recordWatchEvent(reconcilingResourceNSN types.NamespacedName, watchedResource client.Object, ev controllerspi.WatchEventType) {
+func (r *BaseReconciler) recordWatchEvent(wev controllerspi.WatchEvent) {
 	r.watchMutex.Lock()
 	defer r.watchMutex.Unlock()
-	r.watchEvents[reconcilingResourceNSN] = &controllerspi.WatchEvent{
-		EventTime:           time.Now(),
-		ReconcilingResource: reconcilingResourceNSN,
-		WatchEventType:      ev,
-		WatchedResource:     watchedResource,
-	}
+	r.watchEvents[wev.ReconcilingResource] = &wev
 }
 
 // GetLastWatchEvent gets the last WatchEvent for the resource

--- a/pkg/controller/base/basecontroller/watcher_test.go
+++ b/pkg/controller/base/basecontroller/watcher_test.go
@@ -82,8 +82,7 @@ func TestWatch(t *testing.T) {
 				controller:              c,
 				log:                     vzlog.DefaultLogger(),
 				resourceBeingReconciled: nsn,
-				reconciler: newReconciler(nil, ControllerConfig{
-				}),
+				reconciler:              newReconciler(nil, ControllerConfig{}),
 				watchDescriptor: controllerspi.WatchDescriptor{
 					WatchedResourceKind: source.Kind{Type: &moduleapi.Module{}},
 					FuncShouldReconcile: c.shouldReconcile,
@@ -114,7 +113,7 @@ func (w watchController) Watch(src source.Source, eventhandler handler.EventHand
 	return nil
 }
 
-func (w watchController) shouldReconcile(resourceBeingReconciled types.NamespacedName, object client.Object, event controllerspi.WatchEventType) bool {
+func (w watchController) shouldReconcile(cli client.Client, event controllerspi.WatchEvent) bool {
 	return w.predicate
 }
 

--- a/pkg/controller/base/controllerspi/controllerspi.go
+++ b/pkg/controller/base/controllerspi/controllerspi.go
@@ -15,7 +15,7 @@ import (
 )
 
 // FuncShouldReconcile returns true if the watched object event should trigger reconcile
-type FuncShouldReconcile func(reconciledResource types.NamespacedName, watchedObject client.Object, event WatchEventType) bool
+type FuncShouldReconcile func(reconciledResource types.NamespacedName, newWatchedObject client.Object, oldWatchedObject client.Object, event WatchEventType) bool
 
 // FuncControllerEventFilter is the predicate event handler filter that returns true if the object should be reconciled.
 // This is needed to use same CR for multiple controllers

--- a/pkg/controller/base/controllerspi/controllerspi.go
+++ b/pkg/controller/base/controllerspi/controllerspi.go
@@ -15,7 +15,7 @@ import (
 )
 
 // FuncShouldReconcile returns true if the watched object event should trigger reconcile
-type FuncShouldReconcile func(reconciledResource types.NamespacedName, newWatchedObject client.Object, oldWatchedObject client.Object, event WatchEventType) bool
+type FuncShouldReconcile func(cli client.Client, event WatchEvent) bool
 
 // FuncControllerEventFilter is the predicate event handler filter that returns true if the object should be reconciled.
 // This is needed to use same CR for multiple controllers
@@ -52,8 +52,11 @@ type WatchEvent struct {
 	// EventTime is the time the event occurred
 	EventTime time.Time
 
-	// WatchedResource is the resource that caused the event
-	WatchedResource client.Object
+	// NewWatchedObject is the new object that caused the event
+	NewWatchedObject client.Object
+
+	// OldWatchedObject is the old object that caused the event. Only valid for update event
+	OldWatchedObject client.Object
 
 	// ReconcilingResource is the resource that is potentially being reconciled
 	ReconcilingResource types.NamespacedName


### PR DESCRIPTION
Cleanup watch SPI, pass in the watch event and a client.  The oldObject is now available to the watcher.