### PR TITLE
VZ-10544 - prevent concurrent reconcile for same Module CR

### DIFF
--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -211,7 +211,7 @@ func (r Reconciler) checkIfRequeueNeededWhenGenerationsMatch(module *moduleapi.M
 	return result.NewResultShortRequeueDelay()
 }
 
-// checkReentrant will prevent controller-runtime from calling reconcile on the same instance
+// checkConcurrent will prevent controller-runtime from calling reconcile on the same instance
 // concurrently.
 func checkConcurrent(u *unstructured.Unstructured) result.Result {
 	// Make sure controller doesn't call reconcile for the same instance re-entrant

--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -220,8 +220,8 @@ func checkConcurrent(u *unstructured.Unstructured) result.Result {
 
 	nsn := getNsn(u)
 	if _, ok := instanceMap[nsn]; ok {
-		// Wait several seconds to requeue
-		return result.NewResultRequeueDelay(5, 7, time.Second)
+		// Wait a few seconds to requeue
+		return result.NewResultRequeueDelay(2, 3, time.Second)
 	}
 
 	instanceMap[nsn] = true

--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -36,7 +36,7 @@ func IgnoreHelmInfo() {
 func (r Reconciler) Reconcile(spictx controllerspi.ReconcileContext, u *unstructured.Unstructured) result.Result {
 	// Make sure controller doesn't call reconcile for the same instance re-entrant
 	if _, ok := instanceMap[u.GetName()]; ok {
-		panic(nil)
+		return result.NewResult()
 	}
 	instanceMap[u.GetName()] = true
 	defer func() {

--- a/module-operator/controllers/module/reconciler.go
+++ b/module-operator/controllers/module/reconciler.go
@@ -5,6 +5,7 @@ package module
 
 import (
 	"context"
+	"fmt"
 	"github.com/verrazzano/verrazzano-modules/module-operator/controllers/module/status"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
@@ -35,12 +36,13 @@ func IgnoreHelmInfo() {
 // Reconcile reconciles the Module CR
 func (r Reconciler) Reconcile(spictx controllerspi.ReconcileContext, u *unstructured.Unstructured) result.Result {
 	// Make sure controller doesn't call reconcile for the same instance re-entrant
-	if _, ok := instanceMap[u.GetName()]; ok {
+	nsn := fmt.Sprintf("%s-%s", u.GetNamespace(), u.GetName())
+	if _, ok := instanceMap[nsn]; ok {
 		return result.NewResult()
 	}
-	instanceMap[u.GetName()] = true
+	instanceMap[nsn] = true
 	defer func() {
-		delete(instanceMap, u.GetName())
+		delete(instanceMap, nsn)
 	}()
 
 	cr := &moduleapi.Module{}


### PR DESCRIPTION
controller-runtime will call reconcile for the same CR concurrently if maxconcurrentreconciles > 1.  Detect this and requeue.