### PR TITLE
VZ-10544 API CheckDependencies call

### DIFF
--- a/module-operator/controllers/module/handlers/helm/delete/delete_handler.go
+++ b/module-operator/controllers/module/handlers/helm/delete/delete_handler.go
@@ -44,6 +44,10 @@ func (h HelmHandler) PreWork(ctx handlerspi.HandlerContext) result.Result {
 	return result.NewResult()
 }
 
+func (h HelmHandler) CheckDependencies(context handlerspi.HandlerContext) result.Result {
+	return result.NewResult()
+}
+
 // DoWorkUpdateStatus does the work status update
 func (h HelmHandler) DoWorkUpdateStatus(ctx handlerspi.HandlerContext) result.Result {
 	module := ctx.CR.(*moduleapi.Module)

--- a/module-operator/controllers/module/handlers/helm/install/install_handler.go
+++ b/module-operator/controllers/module/handlers/helm/install/install_handler.go
@@ -89,6 +89,10 @@ func (h HelmHandler) DoWork(ctx handlerspi.HandlerContext) result.Result {
 	return h.HelmUpgradeOrInstall(ctx)
 }
 
+func (h HelmHandler)CheckDependencies(context handlerspi.HandlerContext) result.Result {
+	return result.NewResult()
+}
+
 // IsWorkDone Indicates whether a module is installed and ready
 func (h HelmHandler) IsWorkDone(ctx handlerspi.HandlerContext) (bool, result.Result) {
 	return h.CheckReleaseDeployedAndReady(ctx)

--- a/module-operator/controllers/module/handlers/helm/update/update_handler.go
+++ b/module-operator/controllers/module/handlers/helm/update/update_handler.go
@@ -43,6 +43,10 @@ func (h HelmHandler) PreWork(ctx handlerspi.HandlerContext) result.Result {
 	return result.NewResult()
 }
 
+func (h HelmHandler)CheckDependencies(context handlerspi.HandlerContext) result.Result {
+	return result.NewResult()
+}
+
 // DoWorkUpdateStatus updates the status for the work state
 func (h HelmHandler) DoWorkUpdateStatus(ctx handlerspi.HandlerContext) result.Result {
 	module := ctx.CR.(*moduleapi.Module)

--- a/module-operator/controllers/module/handlers/helm/upgrade/upgrade_handler.go
+++ b/module-operator/controllers/module/handlers/helm/upgrade/upgrade_handler.go
@@ -51,6 +51,10 @@ func (h HelmHandler) PreWork(ctx handlerspi.HandlerContext) result.Result {
 	return result.NewResult()
 }
 
+func (h HelmHandler)CheckDependencies(context handlerspi.HandlerContext) result.Result {
+	return result.NewResult()
+}
+
 // DoWorkUpdateStatus updates the status for the work state
 func (h HelmHandler) DoWorkUpdateStatus(ctx handlerspi.HandlerContext) result.Result {
 	module := ctx.CR.(*moduleapi.Module)

--- a/module-operator/controllers/module/reconciler_test.go
+++ b/module-operator/controllers/module/reconciler_test.go
@@ -349,6 +349,10 @@ func (h handler) IsWorkNeeded(context handlerspi.HandlerContext) (bool, result.R
 	return true, result.NewResult()
 }
 
+func (h handler) CheckDependencies(context handlerspi.HandlerContext) result.Result {
+	return result.NewResult()
+}
+
 func (h handler) PreWork(context handlerspi.HandlerContext) result.Result {
 	return result.NewResult()
 }

--- a/pkg/controller/spi/handlerspi/statemachine_handler_spi.go
+++ b/pkg/controller/spi/handlerspi/statemachine_handler_spi.go
@@ -15,6 +15,9 @@ type StateMachineHandler interface {
 	// IsWorkNeeded returns true if work is needed for the Module
 	IsWorkNeeded(context HandlerContext) (bool, result.Result)
 
+	// CheckDependencies checks if dependencies are ready
+	CheckDependencies(context HandlerContext) result.Result
+
 	// PreWorkUpdateStatus does the pre-work status update
 	PreWorkUpdateStatus(context HandlerContext) result.Result
 

--- a/pkg/controller/statemachine/statemachine.go
+++ b/pkg/controller/statemachine/statemachine.go
@@ -37,6 +37,9 @@ const (
 	// stateCheckWorkNeeded is the state to check if work is needed
 	stateCheckWorkNeeded state = "stateCheckWorkNeeded"
 
+	// stateCheckDependencies is the state to check if dependencies are met
+	stateCheckDependencies state = "stateCheckDependencies"
+
 	// statePreWorkUpdateStatus is the state when the status is updated to start pre work
 	statePreWorkUpdateStatus state = "statePreWorkUpdateStatus"
 
@@ -100,8 +103,15 @@ func (s *StateMachine) Execute(handlerContext handlerspi.HandlerContext) result.
 			if !needed {
 				tracker.state = stateEnd
 			} else {
-				tracker.state = statePreWorkUpdateStatus
+				tracker.state = stateCheckDependencies
 			}
+
+		case stateCheckDependencies:
+			res := s.Handler.CheckDependencies(handlerContext)
+			if res.ShouldRequeue() {
+				return res
+			}
+			tracker.state = statePreWorkUpdateStatus
 
 		case statePreWorkUpdateStatus:
 			res := s.Handler.PreWorkUpdateStatus(handlerContext)

--- a/pkg/controller/statemachine/statemachine_test.go
+++ b/pkg/controller/statemachine/statemachine_test.go
@@ -31,6 +31,7 @@ type handler struct {
 const (
 	getWorkName               = "GetWorkName"
 	isWorkNeeded              = "isWorkNeeded"
+	checkDependencies         = "checkDependencies"
 	preWorkUpdateStatus       = "preWorkUpdateStatus"
 	preWork                   = "preWork"
 	workUpdateStatus          = "DoWorkUpdateStatus"
@@ -46,6 +47,7 @@ func getStatesInOrder() []string {
 	return []string{
 		getWorkName,
 		isWorkNeeded,
+		checkDependencies,
 		preWorkUpdateStatus,
 		preWork,
 		workUpdateStatus,
@@ -227,6 +229,10 @@ func (h handler) GetWorkName() string {
 
 func (h handler) IsWorkNeeded(context handlerspi.HandlerContext) (bool, result.Result) {
 	return h.procHandlerBool(isWorkNeeded)
+}
+
+func (h handler) CheckDependencies(context handlerspi.HandlerContext) result.Result {
+	return h.procHandlerCall(checkDependencies)
 }
 
 func (h handler) PreWork(context handlerspi.HandlerContext) result.Result {


### PR DESCRIPTION
Add SPI CheckDependencies call so that we can reduce the likelihood of an update watch forcing a re-reconcile.  This allows us to defer setting the state machine timestamp until after deps are met.  That timestamp is used to determine if a watch should force a reconcile.  If the watch happens after the timestamp then we must re-reconcile.

Also, check if watch occurred during reconciliation so that we know if re-reconcile is needed.