### PR TITLE
OLCNE-5799 build with golang-1.20.12

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -63,7 +63,7 @@ run: ## Run a controller from your host.
 .PHONY: docker-build
 docker-build: docker-build-common
 
-docker-build-common: BASE_IMAGE ?= ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230529051534-037adf4-4653b27@sha256:73c0b081e13228fbbe5fb87b46cde1781cba25bdf9cf6489daa56460e5e1435b
+docker-build-common: BASE_IMAGE ?= ghcr.io/oracle/oraclelinux:9-slim
 .PHONY: docker-build-common
 docker-build-common:
 	@echo Building ${NAME} image ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
@@ -74,7 +74,7 @@ docker-build-common:
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ..
 
 # Cannot use verrazzano-base here until it supports both arm and amd
-docker-build-and-push-multi-arch: BASE_IMAGE ?= ghcr.io/oracle/oraclelinux:8-slim
+docker-build-and-push-multi-arch: BASE_IMAGE ?= ghcr.io/oracle/oraclelinux:9-slim
 .PHONY: docker-build-and-push-multi-arch
 docker-build-and-push-multi-arch: docker-login
 	@echo Building and pushing ${NAME} multi arch image ${DOCKER_IMAGE_FULLNAME}:${DOCKER_IMAGE_TAG}

--- a/module-operator/Dockerfile
+++ b/module-operator/Dockerfile
@@ -1,15 +1,12 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-ARG BASE_IMAGE=ghcr.io/oracle/oraclelinux:8-slim
+ARG BASE_IMAGE=ghcr.io/oracle/oraclelinux:9-slim
 
-FROM ghcr.io/oracle/oraclelinux:8 AS build_base
+FROM ghcr.io/verrazzano/golang:v1.20.12 AS build_base
 
 # Need to use specific WORKDIR to match source packages
 WORKDIR /root/go/src/github.com/verrazzano/verrazzano-modules
 COPY . .
-
-RUN dnf update -y && \
-    dnf install -y golang-1.20.10
 
 # Build the operator binary
 RUN go build -o /usr/local/bin/verrazzano-module-operator ./module-operator/main.go

--- a/module-operator/Dockerfile
+++ b/module-operator/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ARG BASE_IMAGE=ghcr.io/oracle/oraclelinux:9-slim
 
-FROM ghcr.io/verrazzano/golang:v1.20.12 AS build_base
+FROM ghcr.io/verrazzano/oraclelinux-golang:v1.20.12 AS build_base
 
 # Need to use specific WORKDIR to match source packages
 WORKDIR /root/go/src/github.com/verrazzano/verrazzano-modules


### PR DESCRIPTION
Use multi-arch ghcr.io/verrazzano/oraclelinux-golang:v1.20.12 AS build_base. 
Job 4 in https://newbuild.verrazzano.io/job/verrazzano-modules/job/gz%252FOLCNE-5799_go_1.20.12/ has the parameter BUILD_MULTI_ARCH_IMAGES as enabled.